### PR TITLE
Add wrapper for dss

### DIFF
--- a/src/DSS/DSS.jl
+++ b/src/DSS/DSS.jl
@@ -1,0 +1,58 @@
+module DSS
+import Base.LinAlg: BlasInt, BlasFloat, A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!
+
+include("dss_generator.jl")
+include("matstruct.jl")
+
+for (mv, trans) in ((:A_ldiv_B!, MKL_DSS_TRANSPOSE_SOLVE),
+                    (:At_ldiv_B!, 0),
+                    (:Ac_ldiv_B!, 0))
+    @eval begin
+        function $(mv){T<:BlasFloat}(A::SparseMatrixCSC{T,BlasInt},
+                                     B::StridedVecOrMat{T}, X::StridedVecOrMat{T})
+
+            (n = size(A,1)) == size(A,2) || throw(DimensionMismatch())
+            size(A,2) == size(B,1) == size(X,1) || throw(DimensionMismatch())
+            size(B,2) == size(X,2) || throw(DimensionMismatch())
+
+            mat_struct = MatrixSymStructure(A)
+
+            if issym(mat_struct)
+                opt_struct = (T <: Complex ? MKL_DSS_SYMMETRIC_COMPLEX: MKL_DSS_SYMMETRIC)
+                A = tril(A)
+            else
+                opt_struct = (T <: Complex ? MKL_DSS_NON_SYMMETRIC_COMPLEX: MKL_DSS_NON_SYMMETRIC)
+            end
+
+            # Special case needed for CSC -> CSR in case of solving conj transpose
+            if T <: Complex && $mv ==  $(:Ac_ldiv_B!)
+                A = conj(A)
+            end
+
+            handle = dss_create(T)
+            dss_define_structure(handle, A.colptr, n, n, A.rowval, length(A.nzval), opt_struct)
+            dss_reorder(handle, BlasInt[0])
+
+            if ischolcand(mat_struct)
+                try
+                    opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_POSITIVE_DEFINITE: MKL_DSS_POSITIVE_DEFINITE)
+                    dss_factor!(handle, A, opt_factor)
+                catch e
+                    # We should check if the error is actually a pos def error but
+                    # DSS seems to return the wrong error message. See #1
+                    isa(e, MKL_DSS_Exception) || rethrow(e)
+                    opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_INDEFINITE: MKL_DSS_INDEFINITE)
+                    dss_factor!(handle, A, opt_factor)
+                end
+            else
+                dss_factor!(handle, A, MKL_DSS_INDEFINITE)
+            end
+
+            dss_solve!(handle, B, X, $(trans))
+            dss_delete(handle)
+            return X
+        end
+    end
+end
+
+end # module

--- a/src/DSS/dss_generator.jl
+++ b/src/DSS/dss_generator.jl
@@ -1,0 +1,65 @@
+include("mkl_dss_h.jl")
+
+for (T, opt) in ((Union(Float64, Complex128), MKL_DSS_DEFAULTS),
+                 (Union(Float32, Complex64), MKL_DSS_DEFAULTS+MKL_DSS_SINGLE_PRECISION))
+    @eval begin
+        function dss_create{S <: $T}(::Type{S})
+            handle = Int[0]
+            ccall(("dss_create", :libmkl_rt), BlasInt, (Ptr{Void}, Ptr{BlasInt}),
+                        handle, &($(opt)))
+            return handle
+        end
+    end
+end
+
+function dss_define_structure(handle::Vector{Int}, rowindex::Vector{BlasInt},
+                              nrows::BlasInt, ncols::BlasInt, columns::Vector{BlasInt},
+                              nnz::BlasInt, opt::Int=MKL_DSS_DEFAULTS)
+    nrows == ncols || throw(DimensionMismatch())
+    @errcheck ccall(("dss_define_structure", :libmkl_rt), BlasInt,
+                (Ptr{Void}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+                 Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}),
+                handle, &opt, rowindex, &nrows, &ncols, columns, &nnz)
+end
+
+function dss_reorder(handle::Vector{Int}, perm::Vector{BlasInt},
+                     opt::Int=MKL_DSS_DEFAULTS)
+    @errcheck ccall(("dss_reorder", :libmkl_rt), BlasInt,
+                (Ptr{Void}, Ptr{BlasInt}, Ptr{BlasInt}),
+                handle, &opt, perm)
+end
+
+for (mv, T) in ((:dss_factor_real, Float32),
+                (:dss_factor_real, Float64),
+                (:dss_factor_complex, Complex64),
+                (:dss_factor_complex, Complex128))
+    @eval begin
+        function dss_factor!(handle::Vector{Int}, A::SparseMatrixCSC{$T, BlasInt}, opt::Int=MKL_DSS_DEFAULTS)
+            @errcheck ccall(($(string(mv)), :libmkl_rt), BlasInt,
+                        (Ptr{Void}, Ptr{BlasInt}, Ptr{$T}),
+                        handle, &opt, A.nzval)
+        end
+    end
+end
+
+for (mv, T) in ((:dss_solve_real, Float32),
+                (:dss_solve_real, Float64),
+                (:dss_solve_complex, Complex64),
+                (:dss_solve_complex, Complex128))
+    @eval begin
+        function dss_solve!(handle::Vector{Int},B::StridedVecOrMat{$T},
+                            X::StridedVecOrMat{$T}, opt::Int=MKL_DSS_DEFAULTS)
+            size(B) == size(X) || throw(DimensionMismatch())
+            nrhs = size(B, 2)
+            @errcheck ccall(($(string(mv)), :libmkl_rt), BlasInt,
+                        (Ptr{Void}, Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt}, Ptr{$T}),
+                        handle, &opt, B, &nrhs, X)
+        end
+    end
+end
+
+function dss_delete(handle::Vector{Int}, opt::Int=MKL_DSS_DEFAULTS)
+    @errcheck ccall(("dss_delete", :libmkl_rt), BlasInt,
+                (Ptr{Void}, Ptr{BlasInt}),
+                handle, &opt)
+end

--- a/src/DSS/matstruct.jl
+++ b/src/DSS/matstruct.jl
@@ -1,0 +1,62 @@
+import Base: issym, ishermitian
+
+immutable MatrixSymStructure
+    symmetric::Bool
+    hermitian::Bool
+    chol_candidate::Bool
+end
+
+issym(mss::MatrixSymStructure) = mss.symmetric
+ishermitian(mss::MatrixSymStructure) = mss.hermitian
+ischolcand(mss::MatrixSymStructure) = mss.chol_candidate
+
+function MatrixSymStructure(A::SparseMatrixCSC)
+    hermitian = true
+    chol_candidate = true
+    symmetric = true
+
+    m, n = size(A)
+    if m != n; return false; end
+
+    colptr = A.colptr
+    rowval = A.rowval
+    nzval = A.nzval
+    tracker = copy(A.colptr)
+    @inbounds for col = 1:A.n
+        for p = tracker[col]:colptr[col+1]-1
+            val = nzval[p]
+            if val == 0; continue; end # In case of explicit zeros
+            row = rowval[p]
+            if row < col
+                return MatrixSymStructure(false, false, false)
+            elseif row == col # Diagonal element
+                if imag(val) != 0
+                    hermitian = false # Hermitians have real diagonal
+                end
+                if real(val) < 0 || imag(val) != 0 # Cholesky candidates have real pos diag
+                    chol_candidate = false
+                end
+            else
+                row2 = rowval[tracker[row]]
+                val2 = nzval[tracker[row]]
+                if row2 > col
+                    return MatrixSymStructure(false, false, false)
+                end
+                if row2 == col # A[i,j] and A[j,i] exists
+                    if val != val2
+                        symmetric = false
+                    end
+                    if val != conj(val2)
+                        hermitian = false
+                    end
+                    tracker[row] += 1
+                end
+            end
+        end
+        # check if we can abort early
+        if symmetric == false && hermitian == false && chol_candidate == false
+            return MatrixSymStructure(false, false, false)
+        end
+    end
+    return MatrixSymStructure(symmetric, hermitian, chol_candidate)
+end

--- a/src/DSS/mkl_dss_h.jl
+++ b/src/DSS/mkl_dss_h.jl
@@ -1,0 +1,112 @@
+# MKL_DSS_DEFAULTS
+const MKL_DSS_DEFAULTS =  0
+
+
+# Out-of-core level option definitions
+const MKL_DSS_OOC_VARIABLE = 1024
+const MKL_DSS_OOC_STRONG =   2048
+
+
+# Refinement steps on / off
+const MKL_DSS_REFINEMENT_OFF = 4096
+const MKL_DSS_REFINEMENT_ON =  8192
+
+
+# Solver step's substitution
+const MKL_DSS_FORWARD_SOLVE   = 16384
+const MKL_DSS_DIAGONAL_SOLVE  = 32768
+const MKL_DSS_BACKWARD_SOLVE  = 49152
+const MKL_DSS_TRANSPOSE_SOLVE = 262144
+const MKL_DSS_CONJUGATE_SOLVE = 524288
+
+
+# Single precision
+const MKL_DSS_SINGLE_PRECISION = 65536
+
+
+# Zero-based indexing
+const MKL_DSS_ZERO_BASED_INDEXING = 131072
+
+
+# Message level option definitions
+const MKL_DSS_MSG_LVL_SUCCESS = -2147483647
+const MKL_DSS_MSG_LVL_DEBUG   = -2147483646
+const MKL_DSS_MSG_LVL_INFO    = -2147483645
+const MKL_DSS_MSG_LVL_WARNING = -2147483644
+const MKL_DSS_MSG_LVL_ERROR   = -2147483643
+const MKL_DSS_MSG_LVL_FATAL   = -2147483642
+
+
+# Termination level option definitions
+const MKL_DSS_TERM_LVL_SUCCESS   = 1073741832
+const MKL_DSS_TERM_LVL_DEBUG     = 1073741840
+const MKL_DSS_TERM_LVL_INFO      = 1073741848
+const MKL_DSS_TERM_LVL_WARNING   = 1073741856
+const MKL_DSS_TERM_LVL_ERROR     = 1073741864
+const MKL_DSS_TERM_LVL_FATAL     = 1073741872
+
+
+# Structure option definitions
+const MKL_DSS_SYMMETRIC                    = 536870976
+const MKL_DSS_SYMMETRIC_STRUCTURE          = 536871040
+const MKL_DSS_NON_SYMMETRIC                = 536871104
+const MKL_DSS_SYMMETRIC_COMPLEX            = 536871168
+const MKL_DSS_SYMMETRIC_STRUCTURE_COMPLEX  = 536871232
+const MKL_DSS_NON_SYMMETRIC_COMPLEX        = 536871296
+
+
+# Reordering option definitions
+const MKL_DSS_AUTO_ORDER             = 268435520
+const MKL_DSS_MY_ORDER               = 268435584
+const MKL_DSS_OPTION1_ORDER          = 268435648
+const MKL_DSS_GET_ORDER              = 268435712
+const MKL_DSS_METIS_ORDER            = 268435776
+const MKL_DSS_METIS_OPENMP_ORDER     = 268435840
+
+
+# Factorization option definitions
+const MKL_DSS_POSITIVE_DEFINITE           = 134217792
+const MKL_DSS_INDEFINITE                  = 134217856
+const MKL_DSS_HERMITIAN_POSITIVE_DEFINITE = 134217920
+const MKL_DSS_HERMITIAN_INDEFINITE        = 134217984
+
+
+const MKL_DSS_SUCCESS = 0
+# Return status values
+const RETURN_STATS = Dict{Int, ASCIIString}(
+    -1  => "MKL_DSS_ZERO_PIVOT",
+    -2  => "MKL_DSS_OUT_OF_MEMORY",
+    -3  => "MKL_DSS_FAILURE",
+    -4  => "MKL_DSS_ROW_ERR",
+    -5  => "MKL_DSS_COL_ERR",
+    -6  => "MKL_DSS_TOO_FEW_VALUES",
+    -7  => "MKL_DSS_TOO_MANY_VALUES",
+    -8  => "MKL_DSS_NOT_SQUARE",
+    -9  => "MKL_DSS_STATE_ERR",
+    -10 => "MKL_DSS_INVALID_OPTION",
+    -11 => "MKL_DSS_OPTION_CONFLICT",
+    -12 => "MKL_DSS_MSG_LVL_ERR",
+    -13 => "MKL_DSS_TERM_LVL_ERR",
+    -14 => "MKL_DSS_STRUCTURE_ERR",
+    -15 => "MKL_DSS_REORDER_ERR",
+    -16 => "MKL_DSS_VALUES_ERR",
+    -17 => "MKL_DSS_STATISTICS_INVALID_MATRIX",
+    -18 => "MKL_DSS_STATISTICS_INVALID_STATE",
+    -19 => "MKL_DSS_STATISTICS_INVALID_STRING",
+    -20 => "MKL_DSS_REORDER1_ERR",
+    -21 => "MKL_DSS_PREORDER_ERR",
+    -22 => "MKL_DSS_DIAG_ERR",
+    -23 => "MKL_DSS_I32BIT_ERR",
+    -24 => "MKL_DSS_OOC_MEM_ERR",
+    -25 => "MKL_DSS_OOC_OC_ERR",
+    -26 => "MKL_DSS_OOC_RW_ERR")
+
+
+type MKL_DSS_Exception <: Exception
+    msg::AbstractString
+end
+
+
+macro errcheck(A)
+    :(err = $A;  err == MKL_DSS_SUCCESS || throw(MKL_DSS_Exception(RETURN_STATS[err])))
+end

--- a/src/MKLSparse.jl
+++ b/src/MKLSparse.jl
@@ -10,5 +10,6 @@ module MKLSparse
     include("./matdescra.jl")
     include("./generator.jl")
     include("./matmul.jl")
+    include("./DSS/DSS.jl")
 
 end # module

--- a/test/dss.jl
+++ b/test/dss.jl
@@ -1,0 +1,33 @@
+srand(1234)
+
+import Base.LinAlg: At_ldiv_B!, Ac_ldiv_B!
+import MKLSparse.DSS: MatrixSymStructure
+for T in (Float32, Float64, Complex64, Complex128)
+    n = 5
+    A1 = sparse(rand(T, n, n))
+    A2 = A1 + A1'
+    A3 = A1 + A1.'
+    A4 = A1'A1
+    B = rand(T, n, n)
+    X = similar(B)
+
+    @test_throws DimensionMismatch A_ldiv_B!(A1, rand(T, n, n+1), X)
+    @test_throws DimensionMismatch A_ldiv_B!(A1, B, rand(T, n, n+1))
+    @test_throws DimensionMismatch A_ldiv_B!(sparse(rand(T, n+1, n+1)), B, X)
+
+    for A in SparseMatrixCSC[A1, A2, A3, A4]
+        if T == Float32 || T == Complex64
+            continue
+        end
+        msm = MatrixSymStructure(A1)
+        @test issym(A1) == issym(msm)
+        @test ishermitian(A1) == ishermitian(msm)
+    end
+
+    for A in SparseMatrixCSC[A1, A2, A3, A4]
+        @test_approx_eq A_ldiv_B!(A, B, X) full(A)\B
+        @test_approx_eq At_ldiv_B!(A, B, X) full(A.')\B
+        @test_approx_eq Ac_ldiv_B!(A, B, X) full(A')\B
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ sS = sA'sA
 sTl = tril(sS)
 sTu = triu(sS)
 
+include("./dss.jl")
 include("./matdescra.jl")
 include("./matmul.jl")
 


### PR DESCRIPTION
This is a work in progress to implement the direct sparse solver (DSS) interface in MKL.

What is left to do are the following:

- [X] Make it work for complex types.
- [X] Add and test `Ac_ldiv_B`
- [X] Try to run the positive definite solver and in case of zero pivots, fall back to indefinite matrix. Same as [in Base]( https://github.com/JuliaLang/julia/blob/f36ccf03148639d4e11c27e3017cd3b68302a968/base/sparse/linalg.jl#L633). What is weird is that when I run the pos def solver for an indefinite matrix I get a written warning about a zero pivot, but the actual error number being returned from the function does not correspond to a pos def error:
```julia
MKL-DSS-DSS-Error, Zero pivot detected
ERROR: LoadError: LoadError: MKLSparse.DSS.MKL_DSS_Exception("MKL_DSS_TERM_LVL_ERR")
 in dss_factor! at /home/kristoffer/.julia/v0.4/MKLSparse/src/DSS/dss_generator.jl:44
```

Why isn't this error number being returned: https://github.com/JuliaSparse/MKLSparse.jl/compare/master...KristofferC:kc/dss_wrap?expand=1#diff-ff085b6f0a82086cc72fcf0c4e22d52aR77

- [ ] Add methods for dealing with `Symmetric{T, SparseMatrixCSC{T, Ti}}`

Any comments or remarks on this WIP is of course appreciated.