### PR TITLE
Add factorization methods

### DIFF
--- a/src/DSS/DSS.jl
+++ b/src/DSS/DSS.jl
@@ -1,54 +1,76 @@
 module DSS
-import Base.LinAlg: BlasInt, BlasFloat, chksquare, factorize,
+import Base.LinAlg: BlasInt, BlasFloat, chksquare, factorize, show,
        A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B
 
 include("dss_generator.jl")
 include("matstruct.jl")
 
-type DSSFactor{T}
-    A::SparseMatrixCSC{T, BlasInt}
-    handle::Vector{Int}
-    n::Int # Size of matrix
+for ftype in (:CholFactor,:LDLTFactor,:LUFactor)
+    @eval begin
+        type $(ftype){T}
+            A::SparseMatrixCSC{T, BlasInt}
+            handle::Vector{Int}
+            n::Int
+        end
+    end
+end
+
+show(io::IO, luf::CholFactor) = print(io, "DSS Cholesky Factorization of a $(luf.n)-by-$(luf.n) sparse matrix")
+show(io::IO, luf::LDLTFactor) = print(io, "DSS LDT Factorization of a $(luf.n)-by-$(luf.n) sparse matrix")
+show(io::IO, luf::LUFactor) = print(io, "DSS LU Factorization of a $(luf.n)-by-$(luf.n) sparse matrix")
+
+typealias DSSFactors Union{CholFactor}
+
+for (mv, ftype, cm_struct, rm_struct) in
+    ((:cholfact, :CholFactor, MKL_DSS_HERMITIAN_POSITIVE_DEFINITE, MKL_DSS_POSITIVE_DEFINITE),
+     (:ldltfact, :LDLTFactor, MKL_DSS_HERMITIAN_INDEFINITE,        MKL_DSS_INDEFINITE),
+     (:lufact,   :LUFactor,   MKL_DSS_INDEFINITE,                  MKL_DSS_INDEFINITE))
+     @eval begin
+        function $(mv){T<:BlasFloat}(A::SparseMatrixCSC{T,BlasInt})
+            n = chksquare(A)
+            handle = dss_create(T)
+            mat_struct = MatrixSymStructure(A)
+            A = transpose(A)
+            if issym(mat_struct)
+                opt_struct = (T <: Complex ? MKL_DSS_SYMMETRIC_COMPLEX: MKL_DSS_SYMMETRIC)
+                A = tril(A)
+            else
+                opt_struct = (T <: Complex ? MKL_DSS_NON_SYMMETRIC_COMPLEX: MKL_DSS_NON_SYMMETRIC)
+            end
+            dss_define_structure(handle, A.colptr, n, n, A.rowval,
+                                 length(A.nzval), opt_struct)
+            dss_reorder(handle, BlasInt[0])
+
+            opt_factor = (T <: Complex ? $(cm_struct): $(rm_struct))
+            dss_factor!(handle, A, opt_factor)
+
+            F = $(ftype)(A, handle, n)
+            finalizer(F, free!)
+            F
+        end
+    end
 end
 
 function factorize{T<:BlasFloat}(A::SparseMatrixCSC{T, BlasInt})
-
-    n = chksquare(A)
+    chksquare(A)
     mat_struct = MatrixSymStructure(A)
-    # Convert from CSC -> CSR
-    A = transpose(A)
-    if issym(mat_struct)
-        opt_struct = (T <: Complex ? MKL_DSS_SYMMETRIC_COMPLEX: MKL_DSS_SYMMETRIC)
-        A = tril(A)
-    else
-        opt_struct = (T <: Complex ? MKL_DSS_NON_SYMMETRIC_COMPLEX: MKL_DSS_NON_SYMMETRIC)
-    end
-
-    handle = dss_create(T)
-    dss_define_structure(handle, A.colptr, n, n, A.rowval,
-                         length(A.nzval), opt_struct)
-    dss_reorder(handle, BlasInt[0])
-
     if ischolcand(mat_struct)
         try
-            opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_POSITIVE_DEFINITE: MKL_DSS_POSITIVE_DEFINITE)
-            dss_factor!(handle, A, opt_factor)
+            return cholfact(A)
         catch e
             # We should check if the error is actually a pos def error but
-            # DSS seems to return the wrong error message. See #1
+            # DSS seems to return the wrong error message. See #2
             isa(e, MKL_DSS_Exception) || rethrow(e)
-            opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_INDEFINITE: MKL_DSS_INDEFINITE)
-            dss_factor!(handle, A, opt_factor)
         end
-    else
-        dss_factor!(handle, A, MKL_DSS_INDEFINITE)
     end
-    F = DSSFactor(A, handle, n)
-    finalizer(F, free!)
-    F
+    if ishermitian(mat_struct)
+        return ldltfact(A)
+    else
+        return lufact(A)
+    end
 end
 
-function free!(F::DSSFactor)
+function free!{T <: Union{LDLTFactor, CholFactor, LUFactor}}(F::T)
     dss_delete(F.handle)
 end
 
@@ -65,38 +87,42 @@ for mv in ((:A_ldiv_B! ),
     end
 end
 
-for (mv, trans) in ((:A_ldiv_B!,  MKL_DSS_DEFAULTS),
-                    (:At_ldiv_B!, MKL_DSS_TRANSPOSE_SOLVE),
-                    (:Ac_ldiv_B!, MKL_DSS_CONJUGATE_SOLVE))
-    @eval begin
-        function $(mv){T<:BlasFloat}(F::DSSFactor,
-                                     B::StridedVecOrMat{T},
-                                     X::StridedVecOrMat{T})
-            F.n == size(B,1) == size(X,1) || throw(DimensionMismatch())
-            size(B,2) == size(X,2) || throw(DimensionMismatch())
-            dss_solve!(F.handle, B, X, $(trans))
-            return X
+for fact in (:CholFactor, :LDLTFactor, :LUFactor)
+    for (mv, trans) in ((:A_ldiv_B!,  MKL_DSS_DEFAULTS),
+                        (:At_ldiv_B!, MKL_DSS_TRANSPOSE_SOLVE),
+                        (:Ac_ldiv_B!, MKL_DSS_CONJUGATE_SOLVE))
+        @eval begin
+            function $(mv){T<:BlasFloat}(F::$fact,
+                                         B::StridedVecOrMat{T},
+                                         X::StridedVecOrMat{T})
+                F.n == size(B,1) == size(X,1) || throw(DimensionMismatch())
+                size(B,2) == size(X,2) || throw(DimensionMismatch())
+                dss_solve!(F.handle, B, X, $(trans))
+                return X
+            end
         end
     end
 end
 
 # Non mutating functions
-for (mv, mv!) in ((:A_ldiv_B,  :A_ldiv_B!),
-                  (:At_ldiv_B, :At_ldiv_B!),
-                  (:Ac_ldiv_B, :Ac_ldiv_B!))
-    @eval begin
-        function $(mv){T<:BlasFloat}(F::DSSFactor,
-                                     B::StridedVecOrMat{T})
-            X = similar(B)
-            return $(mv!)(F, B, X)
+for fact in (:CholFactor, :LDLTFactor, :LUFactor)
+    for (mv, mv!) in ((:A_ldiv_B,  :A_ldiv_B!),
+                      (:At_ldiv_B, :At_ldiv_B!),
+                      (:Ac_ldiv_B, :Ac_ldiv_B!))
+        @eval begin
+            function $(mv){T<:BlasFloat}(F::$fact,
+                                         B::StridedVecOrMat{T})
+                X = similar(B)
+                return $(mv!)(F, B, X)
+            end
         end
-    end
 
-   @eval begin
-        function $(mv){T<:BlasFloat}(A::SparseMatrixCSC{T,BlasInt},
-                                     B::StridedVecOrMat{T})
-            X = similar(B)
-            return $(mv!)(A, B, X)
+       @eval begin
+            function $(mv){T<:BlasFloat}(A::SparseMatrixCSC{T,BlasInt},
+                                         B::StridedVecOrMat{T})
+                X = similar(B)
+                return $(mv!)(A, B, X)
+            end
         end
     end
 end

--- a/src/DSS/DSS.jl
+++ b/src/DSS/DSS.jl
@@ -11,10 +11,7 @@ type DSSFactor{T}
     ftype::ASCIIString
     n::Int
 end
-
-
-show(io::IO, luf::DSSFactor) = print(io, "DSS $luf.ftype Factorization of a $(luf.n)-by-$(luf.n) sparse matrix")
-
+show(io::IO, luf::DSSFactor) = print(io, "DSS $(luf.ftype) Factorization of a $(luf.n)-by-$(luf.n) sparse matrix")
 
 for (mv, ftype, cm_struct, rm_struct) in
     ((:cholfact, "Cholesky", MKL_DSS_HERMITIAN_POSITIVE_DEFINITE, MKL_DSS_POSITIVE_DEFINITE),

--- a/src/DSS/DSS.jl
+++ b/src/DSS/DSS.jl
@@ -1,56 +1,102 @@
 module DSS
-import Base.LinAlg: BlasInt, BlasFloat, A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!
+import Base.LinAlg: BlasInt, BlasFloat, chksquare, factorize,
+       A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B
 
 include("dss_generator.jl")
 include("matstruct.jl")
 
-for (mv, trans) in ((:A_ldiv_B!, MKL_DSS_TRANSPOSE_SOLVE),
-                    (:At_ldiv_B!, 0),
-                    (:Ac_ldiv_B!, 0))
+type DSSFactor{T}
+    A::SparseMatrixCSC{T, BlasInt}
+    handle::Vector{Int}
+    n::Int # Size of matrix
+end
+
+function factorize{T<:BlasFloat}(A::SparseMatrixCSC{T, BlasInt})
+
+    n = chksquare(A)
+    mat_struct = MatrixSymStructure(A)
+    # Convert from CSC -> CSR
+    A = transpose(A)
+    if issym(mat_struct)
+        opt_struct = (T <: Complex ? MKL_DSS_SYMMETRIC_COMPLEX: MKL_DSS_SYMMETRIC)
+        A = tril(A)
+    else
+        opt_struct = (T <: Complex ? MKL_DSS_NON_SYMMETRIC_COMPLEX: MKL_DSS_NON_SYMMETRIC)
+    end
+
+    handle = dss_create(T)
+    dss_define_structure(handle, A.colptr, n, n, A.rowval,
+                         length(A.nzval), opt_struct)
+    dss_reorder(handle, BlasInt[0])
+
+    if ischolcand(mat_struct)
+        try
+            opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_POSITIVE_DEFINITE: MKL_DSS_POSITIVE_DEFINITE)
+            dss_factor!(handle, A, opt_factor)
+        catch e
+            # We should check if the error is actually a pos def error but
+            # DSS seems to return the wrong error message. See #1
+            isa(e, MKL_DSS_Exception) || rethrow(e)
+            opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_INDEFINITE: MKL_DSS_INDEFINITE)
+            dss_factor!(handle, A, opt_factor)
+        end
+    else
+        dss_factor!(handle, A, MKL_DSS_INDEFINITE)
+    end
+    F = DSSFactor(A, handle, n)
+    finalizer(F, free!)
+    F
+end
+
+function free!(F::DSSFactor)
+    dss_delete(F.handle)
+end
+
+for mv in ((:A_ldiv_B! ),
+           (:At_ldiv_B!),
+           (:Ac_ldiv_B!))
     @eval begin
         function $(mv){T<:BlasFloat}(A::SparseMatrixCSC{T,BlasInt},
-                                     B::StridedVecOrMat{T}, X::StridedVecOrMat{T})
+                                     B::StridedVecOrMat{T},
+                                     X::StridedVecOrMat{T})
+            F = factorize(A)
+            return $(mv)(F, B, X)
+        end
+    end
+end
 
-            (n = size(A,1)) == size(A,2) || throw(DimensionMismatch())
-            size(A,2) == size(B,1) == size(X,1) || throw(DimensionMismatch())
+for (mv, trans) in ((:A_ldiv_B!,  MKL_DSS_DEFAULTS),
+                    (:At_ldiv_B!, MKL_DSS_TRANSPOSE_SOLVE),
+                    (:Ac_ldiv_B!, MKL_DSS_CONJUGATE_SOLVE))
+    @eval begin
+        function $(mv){T<:BlasFloat}(F::DSSFactor,
+                                     B::StridedVecOrMat{T},
+                                     X::StridedVecOrMat{T})
+            F.n == size(B,1) == size(X,1) || throw(DimensionMismatch())
             size(B,2) == size(X,2) || throw(DimensionMismatch())
-
-            mat_struct = MatrixSymStructure(A)
-
-            if issym(mat_struct)
-                opt_struct = (T <: Complex ? MKL_DSS_SYMMETRIC_COMPLEX: MKL_DSS_SYMMETRIC)
-                A = tril(A)
-            else
-                opt_struct = (T <: Complex ? MKL_DSS_NON_SYMMETRIC_COMPLEX: MKL_DSS_NON_SYMMETRIC)
-            end
-
-            # Special case needed for CSC -> CSR in case of solving conj transpose
-            if T <: Complex && $mv ==  $(:Ac_ldiv_B!)
-                A = conj(A)
-            end
-
-            handle = dss_create(T)
-            dss_define_structure(handle, A.colptr, n, n, A.rowval, length(A.nzval), opt_struct)
-            dss_reorder(handle, BlasInt[0])
-
-            if ischolcand(mat_struct)
-                try
-                    opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_POSITIVE_DEFINITE: MKL_DSS_POSITIVE_DEFINITE)
-                    dss_factor!(handle, A, opt_factor)
-                catch e
-                    # We should check if the error is actually a pos def error but
-                    # DSS seems to return the wrong error message. See #1
-                    isa(e, MKL_DSS_Exception) || rethrow(e)
-                    opt_factor = (T <: Complex ? MKL_DSS_HERMITIAN_INDEFINITE: MKL_DSS_INDEFINITE)
-                    dss_factor!(handle, A, opt_factor)
-                end
-            else
-                dss_factor!(handle, A, MKL_DSS_INDEFINITE)
-            end
-
-            dss_solve!(handle, B, X, $(trans))
-            dss_delete(handle)
+            dss_solve!(F.handle, B, X, $(trans))
             return X
+        end
+    end
+end
+
+# Non mutating functions
+for (mv, mv!) in ((:A_ldiv_B,  :A_ldiv_B!),
+                  (:At_ldiv_B, :At_ldiv_B!),
+                  (:Ac_ldiv_B, :Ac_ldiv_B!))
+    @eval begin
+        function $(mv){T<:BlasFloat}(F::DSSFactor,
+                                     B::StridedVecOrMat{T})
+            X = similar(B)
+            return $(mv!)(F, B, X)
+        end
+    end
+
+   @eval begin
+        function $(mv){T<:BlasFloat}(A::SparseMatrixCSC{T,BlasInt},
+                                     B::StridedVecOrMat{T})
+            X = similar(B)
+            return $(mv!)(A, B, X)
         end
     end
 end

--- a/src/DSS/matstruct.jl
+++ b/src/DSS/matstruct.jl
@@ -58,5 +58,5 @@ function MatrixSymStructure(A::SparseMatrixCSC)
             return MatrixSymStructure(false, false, false)
         end
     end
-    return MatrixSymStructure(symmetric, hermitian, chol_candidate)
+    MatrixSymStructure(symmetric, hermitian, chol_candidate)
 end

--- a/src/DSS/matstruct.jl
+++ b/src/DSS/matstruct.jl
@@ -48,6 +48,7 @@ function MatrixSymStructure(A::SparseMatrixCSC)
                     end
                     if val != conj(val2)
                         hermitian = false
+                        chol_candidate = false
                     end
                     tracker[row] += 1
                 end

--- a/test/dss.jl
+++ b/test/dss.jl
@@ -19,9 +19,9 @@ for T in (Float32, Float64, Complex64, Complex128)
         if T == Float32 || T == Complex64
             continue
         end
-        msm = MatrixSymStructure(A1)
-        @test issym(A1) == issym(msm)
-        @test ishermitian(A1) == ishermitian(msm)
+        msm = MatrixSymStructure(A)
+        @test issym(A) == issym(msm)
+        @test ishermitian(A) == ishermitian(msm)
     end
 
     for A in SparseMatrixCSC[A1, A2, A3, A4]

--- a/test/dss.jl
+++ b/test/dss.jl
@@ -1,7 +1,9 @@
 srand(1234)
 
-import Base.LinAlg: At_ldiv_B!, Ac_ldiv_B!
+import Base.LinAlg: factorize,
+       A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B
 import MKLSparse.DSS: MatrixSymStructure
+
 for T in (Float32, Float64, Complex64, Complex128)
     n = 5
     A1 = sparse(rand(T, n, n))
@@ -15,6 +17,10 @@ for T in (Float32, Float64, Complex64, Complex128)
     @test_throws DimensionMismatch A_ldiv_B!(A1, B, rand(T, n, n+1))
     @test_throws DimensionMismatch A_ldiv_B!(sparse(rand(T, n+1, n+1)), B, X)
 
+    @test_throws DimensionMismatch A_ldiv_B(A1, rand(T, n+1, n))
+    @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n+1, n+1)), B)
+    @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n, n+1)), B)
+
     for A in SparseMatrixCSC[A1, A2, A3, A4]
         if T == Float32 || T == Complex64
             continue
@@ -25,9 +31,22 @@ for T in (Float32, Float64, Complex64, Complex128)
     end
 
     for A in SparseMatrixCSC[A1, A2, A3, A4]
+        F = factorize(A)
+
+        @test_approx_eq A_ldiv_B!(F, B, X) full(A)\B
+        @test_approx_eq At_ldiv_B!(F, B, X) full(A.')\B
+        @test_approx_eq Ac_ldiv_B!(F, B, X) full(A')\B
+
+        @test_approx_eq A_ldiv_B(F, B) full(A)\B
+        @test_approx_eq At_ldiv_B(F, B) full(A.')\B
+        @test_approx_eq Ac_ldiv_B(F, B) full(A')\B
+
         @test_approx_eq A_ldiv_B!(A, B, X) full(A)\B
         @test_approx_eq At_ldiv_B!(A, B, X) full(A.')\B
         @test_approx_eq Ac_ldiv_B!(A, B, X) full(A')\B
-    end
 
+        @test_approx_eq A_ldiv_B(A, B) full(A)\B
+        @test_approx_eq At_ldiv_B(A, B) full(A.')\B
+        @test_approx_eq Ac_ldiv_B(A, B) full(A')\B
+    end
 end

--- a/test/dss.jl
+++ b/test/dss.jl
@@ -13,14 +13,6 @@ for T in (Float32, Float64, Complex64, Complex128)
     B = rand(T, n, n)
     X = similar(B)
 
-    @test_throws DimensionMismatch A_ldiv_B!(A1, rand(T, n, n+1), X)
-    @test_throws DimensionMismatch A_ldiv_B!(A1, B, rand(T, n, n+1))
-    @test_throws DimensionMismatch A_ldiv_B!(sparse(rand(T, n+1, n+1)), B, X)
-
-    @test_throws DimensionMismatch A_ldiv_B(A1, rand(T, n+1, n))
-    @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n+1, n+1)), B)
-    @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n, n+1)), B)
-
     for A in SparseMatrixCSC[A1, A2, A3, A4]
         if T == Float32 || T == Complex64
             continue
@@ -49,4 +41,13 @@ for T in (Float32, Float64, Complex64, Complex128)
         @test_approx_eq At_ldiv_B(A, B) full(A.')\B
         @test_approx_eq Ac_ldiv_B(A, B) full(A')\B
     end
+
+    @test_throws DimensionMismatch A_ldiv_B!(A1, rand(T, n, n+1), X)
+    @test_throws DimensionMismatch A_ldiv_B!(A1, B, rand(T, n, n+1))
+    @test_throws DimensionMismatch A_ldiv_B!(sparse(rand(T, n+1, n+1)), B, X)
+
+    @test_throws DimensionMismatch A_ldiv_B(A1, rand(T, n+1, n))
+    @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n+1, n+1)), B)
+    @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n, n+1)), B)
+
 end


### PR DESCRIPTION
This implements the functionality that `factorize(A)` now gives a `Factor` type which can be used to solve equations.

One concern is that the garbage collector currently does not know how much memory a `Factor` type actually represents, same as commented here: https://github.com/JuliaLang/julia/issues/11698#issuecomment-111702530

Maybe [`dss_statistics`](https://software.intel.com/en-us/node/470322) can be used to get the memory consumption and then use [`jl_gc_count_allocd`](https://github.com/JuliaLang/julia/blob/84f14d1e6a6650f75506e5ec9b6d9bcdd64e168c/src/gc.c#L965) to add it.
