### PR TITLE
Refactor to avoid unnecessary symmetric checking in factorize method.

### DIFF
--- a/src/DSS/mkl_dss_h.jl
+++ b/src/DSS/mkl_dss_h.jl
@@ -102,11 +102,11 @@ const RETURN_STATS = Dict{Int, ASCIIString}(
     -26 => "MKL_DSS_OOC_RW_ERR")
 
 
-type MKL_DSS_Exception <: Exception
+type DSSError <: Exception
     msg::AbstractString
 end
 
 
 macro errcheck(A)
-    :(err = $A;  err == MKL_DSS_SUCCESS || throw(MKL_DSS_Exception(RETURN_STATS[err])))
+    :(err = $A;  err == MKL_DSS_SUCCESS || throw(DSSError(RETURN_STATS[err])))
 end

--- a/test/dss.jl
+++ b/test/dss.jl
@@ -2,7 +2,8 @@ srand(1234)
 
 import Base.LinAlg: factorize,
        A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B
-import MKLSparse.DSS: MatrixSymStructure
+import MKLSparse.DSS: MatrixSymStructure, DSSError,
+                      cholfact, ldltfact, lufact
 
 for T in (Float32, Float64, Complex64, Complex128)
     n = 5
@@ -23,16 +24,6 @@ for T in (Float32, Float64, Complex64, Complex128)
     end
 
     for A in SparseMatrixCSC[A1, A2, A3, A4]
-        F = factorize(A)
-
-        @test_approx_eq A_ldiv_B!(F, B, X) full(A)\B
-        @test_approx_eq At_ldiv_B!(F, B, X) full(A.')\B
-        @test_approx_eq Ac_ldiv_B!(F, B, X) full(A')\B
-
-        @test_approx_eq A_ldiv_B(F, B) full(A)\B
-        @test_approx_eq At_ldiv_B(F, B) full(A.')\B
-        @test_approx_eq Ac_ldiv_B(F, B) full(A')\B
-
         @test_approx_eq A_ldiv_B!(A, B, X) full(A)\B
         @test_approx_eq At_ldiv_B!(A, B, X) full(A.')\B
         @test_approx_eq Ac_ldiv_B!(A, B, X) full(A')\B
@@ -40,6 +31,33 @@ for T in (Float32, Float64, Complex64, Complex128)
         @test_approx_eq A_ldiv_B(A, B) full(A)\B
         @test_approx_eq At_ldiv_B(A, B) full(A.')\B
         @test_approx_eq Ac_ldiv_B(A, B) full(A')\B
+
+        for fact in (factorize, lufact, ldltfact, cholfact)
+            # If factorization succeeds it should give correct answer.
+            fact_failed = false
+            F = 0.0 # To put F in scope... maybe better way to do this?
+            try
+                F = fact(A)
+            catch e
+                if isa(e, ArgumentError) || isa(e, DSSError)
+                    fact_failed = true
+                else
+                    rethrow(e)
+                end
+            end
+
+            if fact_failed
+                continue
+            end
+
+            @test_approx_eq A_ldiv_B!(F, B, X) full(A)\B
+            @test_approx_eq At_ldiv_B!(F, B, X) full(A.')\B
+            @test_approx_eq Ac_ldiv_B!(F, B, X) full(A')\B
+
+            @test_approx_eq A_ldiv_B(F, B) full(A)\B
+            @test_approx_eq At_ldiv_B(F, B) full(A.')\B
+            @test_approx_eq Ac_ldiv_B(F, B) full(A')\B
+        end
     end
 
     @test_throws DimensionMismatch A_ldiv_B!(A1, rand(T, n, n+1), X)
@@ -50,4 +68,32 @@ for T in (Float32, Float64, Complex64, Complex128)
     @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n+1, n+1)), B)
     @test_throws DimensionMismatch A_ldiv_B(sparse(rand(T, n, n+1)), B)
 
+end
+
+for T in (Float32, Float64, Complex64, Complex128)
+    n = 5
+    A1 = sparse(rand(T, n, n))
+    A2 = A1 + A1'
+    A3 = A1 + A1.'
+    A4 = A1'A1
+    B = rand(T, n, n)
+    X = similar(B)
+
+    @test_throws ArgumentError cholfact(A1)
+
+    if T <: Complex
+        # Will have complex diagonal so not candidate for chol
+        #
+        #@test_throws DSSError cholfact(A2)
+        @test_throws ArgumentError cholfact(A3)
+    else
+        # Will not be pos def
+        @test_throws DSSError cholfact(A2)
+        @test_throws DSSError cholfact(A2)
+    end
+
+    if T <: Complex
+        @test_throws ArgumentError ldltfact(A1)
+        @test_throws ArgumentError ldltfact(A3)
+    end
 end


### PR DESCRIPTION
Previously the general `factorize` function called the specific function ex `cholfact`, and checks for symmetry was made in both functions.

This makes it so that symmetry is only checked once, regardless if general `factorize` is called or the specific factorization methods.