### PR TITLE
Overload * and \ among a few things

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # MKLSparse.jl
 
-Override sparse-dense operations when MKL is available.
+`MKLSparse.jl` is a Julia package to override sparse-dense operations when MKL is available. It also provides an interface to MKL's Direct Sparse Solver which can be used to factorize and solve sparse system of equations.
+
+In order to use `MKLSparse.jl`you need to have built Julia with MKL as the BLAS library. For instructions how to do so, please see [this link](https://github.com/JuliaLang/julia#intel-compilers-and-math-kernel-library-mkl)
+
+### Matrix multiplication
+
+Loading `MKLSparse.jl` will make sparse-dense matrix operation be computed using MKL. Sparse-sparse operations are not yet wrapped.
+
+
+### Factorization
+
+After `MKLSparse.jl` is loaded, the methods `factorize`, `lufact`, `cholfact`, `ldltfact` will now instead be computed using MKL. The returned factorization objects can be used to solve equations with backslash just like normally. MKL will also be used if the `A\B` syntax is used and `A` is sparse.
+
+Note, due to an unresolved ambiguity problem you currently need to use `MKLSparse.DSS.lufact` to use the lu factorization.

--- a/src/DSS/DSS.jl
+++ b/src/DSS/DSS.jl
@@ -1,6 +1,7 @@
 module DSS
 import Base.LinAlg: BlasInt, BlasFloat, chksquare, factorize, show,
-       A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B
+       A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B,
+       cholfact, ldltfact, factorize, \
 
 include("dss_generator.jl")
 include("matstruct.jl")
@@ -142,5 +143,7 @@ for (mv, mv!) in ((:A_ldiv_B,  :A_ldiv_B!),
     end
 end
 
+(\){T}(F::DSSFactor{T}, B::StridedVecOrMat{T}) = A_ldiv_B(F, B)
+(\){T<:BlasFloat}(A::SparseMatrixCSC{T,BlasInt}, B::StridedVecOrMat{T}) = A_ldiv_B(factorize(A), B)
 
 end # module

--- a/src/DSS/dss_generator.jl
+++ b/src/DSS/dss_generator.jl
@@ -23,7 +23,7 @@ function dss_define_structure(handle::Vector{Int}, rowindex::Vector{BlasInt},
 end
 
 function dss_reorder(handle::Vector{Int}, perm::Vector{BlasInt},
-                     opt::Int=MKL_DSS_DEFAULTS)
+                     opt::Int=MKL_DSS_AUTO_ORDER)
     @errcheck ccall(("dss_reorder", :libmkl_rt), BlasInt,
                 (Ptr{Void}, Ptr{BlasInt}, Ptr{BlasInt}),
                 handle, &opt, perm)

--- a/src/generator.jl
+++ b/src/generator.jl
@@ -2,73 +2,81 @@ for (mv, sv, mm, sm, T) in ((:mkl_scscmv_, :mkl_scscsv_, :mkl_scscmm_, :mkl_scsc
                             (:mkl_dcscmv_, :mkl_dcscsv_, :mkl_dcscmm_, :mkl_dcscsm_, :Float64),
                             (:mkl_ccscmv_, :mkl_ccscsv_, :mkl_ccscmm_, :mkl_ccscsm_, :Complex64),
                             (:mkl_zcscmv_, :mkl_zcscsv_, :mkl_zcscmm_, :mkl_zcscsm_, :Complex128))
-    @eval begin
-        function cscmv!(transa::Char, α::$T, matdescra::ASCIIString, A::SparseMatrixCSC{$T, BlasInt}, x::StridedVector{$T}, β::$T, y::StridedVector{$T})
-            trns = uppercase(transa)
-            in(trns,['N','T']) || error("uppercase(transa) is '$trns', must be 'N' or 'T'")
-            length(x) == (trns == 'T' ? A.m : A.n) ||
-                throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with vector of length $(length(x))"))
-            length(y) == (trns == 'T' ? A.n : A.m) ||
-                throw(DimensionMismatch("Vector of length $(A.m) added to vector of length $(length(y))"))
-            ccall(($(string(mv)), :libmkl_rt), Void,
-                (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T},
-                 Ptr{Uint8}, Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt},
-                 Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{$T}),
-                &transa, &A.m, &A.n, &α,
-                matdescra, A.nzval, A.rowval, pointer(A.colptr, 1),
-                pointer(A.colptr, 2), x, &β, y)
-            return y
-        end
+@eval begin
+function cscmv!(transa::Char, α::$T, matdescra::ASCIIString,
+                A::SparseMatrixCSC{$T, BlasInt}, x::StridedVector{$T},
+                β::$T, y::StridedVector{$T})
+    trns = uppercase(transa)
+    in(trns,['N','T']) || error("uppercase(transa) is '$trns', must be 'N' or 'T'")
+    length(x) == (trns == 'T' ? A.m : A.n) ||
+        throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with vector of length $(length(x))"))
+    length(y) == (trns == 'T' ? A.n : A.m) ||
+        throw(DimensionMismatch("Vector of length $(A.m) added to vector of length $(length(y))"))
+    ccall(($(string(mv)), :libmkl_rt), Void,
+        (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T},
+         Ptr{Uint8}, Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt},
+         Ptr{BlasInt}, Ptr{$T}, Ptr{$T}, Ptr{$T}),
+        &transa, &A.m, &A.n, &α,
+        matdescra, A.nzval, A.rowval, pointer(A.colptr, 1),
+        pointer(A.colptr, 2), x, &β, y)
+    return y
+end
 
-        function cscsv!(transa::Char, α::$T, matdescra::ASCIIString, A::SparseMatrixCSC{$T, BlasInt}, x::StridedVector{$T}, y::StridedVector{$T})
-            A.m == A.n || throw(DimensionMismatch("Matrix must be square"))
-            length(x) == A.n || throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with vector of length $(length(x))"))
-            length(y) >= A.m || throw(DimensionMismatch("Vector of length $(A.m) assigned to vector of length $(length(y))"))
-            ccall(($(string(sv)), :libmkl_rt), Void,
-                (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$T}, Ptr{Uint8},
-                 Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
-                 Ptr{$T}, Ptr{$T}),
-                &transa, &A.m, &α, matdescra,
-                A.nzval, A.rowval, pointer(A.colptr, 1), pointer(A.colptr, 2),
-                x, y)
-            return y
-        end
+function cscsv!(transa::Char, α::$T, matdescra::ASCIIString,
+                A::SparseMatrixCSC{$T, BlasInt}, x::StridedVector{$T},
+                y::StridedVector{$T})
+    A.m == A.n || throw(DimensionMismatch("Matrix must be square"))
+    length(x) == A.n || throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with vector of length $(length(x))"))
+    length(y) >= A.m || throw(DimensionMismatch("Vector of length $(A.m) assigned to vector of length $(length(y))"))
+    ccall(($(string(sv)), :libmkl_rt), Void,
+        (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$T}, Ptr{Uint8},
+         Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+         Ptr{$T}, Ptr{$T}),
+        &transa, &A.m, &α, matdescra,
+        A.nzval, A.rowval, pointer(A.colptr, 1), pointer(A.colptr, 2),
+        x, y)
+    return y
+end
 
-        function cscmm!(transa::Char, α::$T, matdescra::ASCIIString, A::SparseMatrixCSC{$T, BlasInt}, B::StridedMatrix{$T}, β::$T, C::StridedMatrix{$T})
-            mB, nB = size(B)
-            mC, nC = size(C)
-            A.n == mB || throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with matrix with $(mB) rows"))
-            A.m == mC || throw(DimensionMismatch("Matrix with $(A.m) rows added to matrix with $(mC) rows"))
-            nB == nC || throw(DimensionMismatch("Matrix with $(nB) columns added to matrix with $(nC) columns"))
-            ccall(($(string(mm)), :libmkl_rt), Void,
-                (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
-                 Ptr{$T}, Ptr{Uint8}, Ptr{$T}, Ptr{BlasInt},
-                 Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt},
-                 Ptr{$T}, Ptr{$T}, Ptr{BlasInt}),
-                &transa, &A.m, &nC, &A.n,
-                &α, matdescra, A.nzval, A.rowval,
-                pointer(A.colptr, 1), pointer(A.colptr, 2), B, &mB,
-                &β, C, &mC)
-            return C
-        end
+function cscmm!(transa::Char, α::$T, matdescra::ASCIIString,
+                A::SparseMatrixCSC{$T, BlasInt}, B::StridedMatrix{$T},
+                β::$T, C::StridedMatrix{$T})
+    mB, nB = size(B)
+    mC, nC = size(C)
+    A.n == mB || throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with matrix with $(mB) rows"))
+    A.m == mC || throw(DimensionMismatch("Matrix with $(A.m) rows added to matrix with $(mC) rows"))
+    nB == nC || throw(DimensionMismatch("Matrix with $(nB) columns added to matrix with $(nC) columns"))
+    ccall(($(string(mm)), :libmkl_rt), Void,
+        (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+         Ptr{$T}, Ptr{Uint8}, Ptr{$T}, Ptr{BlasInt},
+         Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt},
+         Ptr{$T}, Ptr{$T}, Ptr{BlasInt}),
+        &transa, &A.m, &nC, &A.n,
+        &α, matdescra, A.nzval, A.rowval,
+        pointer(A.colptr, 1), pointer(A.colptr, 2), B, &mB,
+        &β, C, &mC)
+    return C
+end
 
-        function cscsm!(transa::Char, α::$T, matdescra::ASCIIString, A::SparseMatrixCSC{$T, BlasInt}, B::StridedMatrix{$T}, C::StridedMatrix{$T})
-            mB, nB = size(B)
-            mC, nC = size(C)
-            A.m == A.n || throw(DimensionMismatch("Matrix must be square"))
-            A.n == mB || throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with matrix with $(mB) rows"))
-            A.m <= mC || throw(DimensionMismatch("Matrix with $(A.m) rows assigned to matrix with $(mC) rows"))
-            nB <= nC || throw(DimensionMismatch("Matrix with $(nB) columns assigned to matrix with $(nC) columns"))
-            ccall(($(string(sm)), :libmkl_rt), Void,
-                (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T},
-                 Ptr{Uint8}, Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt},
-                 Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt}, Ptr{$T},
-                 Ptr{BlasInt}),
-                &transa, &A.n, &nC, &α,
-                matdescra, A.nzval, A.rowval, pointer(A.colptr, 1),
-                pointer(A.colptr, 2), B, &mB, C,
-                &mC)
-            return C
-        end
-    end
+function cscsm!(transa::Char, α::$T, matdescra::ASCIIString,
+                A::SparseMatrixCSC{$T, BlasInt}, B::StridedMatrix{$T},
+                C::StridedMatrix{$T})
+    mB, nB = size(B)
+    mC, nC = size(C)
+    A.m == A.n || throw(DimensionMismatch("Matrix must be square"))
+    A.n == mB || throw(DimensionMismatch("Matrix with $(A.n) columns multiplied with matrix with $(mB) rows"))
+    A.m <= mC || throw(DimensionMismatch("Matrix with $(A.m) rows assigned to matrix with $(mC) rows"))
+    nB <= nC || throw(DimensionMismatch("Matrix with $(nB) columns assigned to matrix with $(nC) columns"))
+    ccall(($(string(sm)), :libmkl_rt), Void,
+        (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$T},
+         Ptr{Uint8}, Ptr{$T}, Ptr{BlasInt}, Ptr{BlasInt},
+         Ptr{BlasInt}, Ptr{$T}, Ptr{BlasInt}, Ptr{$T},
+         Ptr{BlasInt}),
+        &transa, &A.n, &nC, &α,
+        matdescra, A.nzval, A.rowval, pointer(A.colptr, 1),
+        pointer(A.colptr, 2), B, &mB, C,
+        &mC)
+    return C
+end
+end
 end

--- a/test/dss.jl
+++ b/test/dss.jl
@@ -1,7 +1,6 @@
 srand(1234)
 
-import Base.LinAlg: factorize,
-       A_ldiv_B!, At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B
+import Base.LinAlg: At_ldiv_B!, Ac_ldiv_B!, A_ldiv_B, At_ldiv_B, Ac_ldiv_B
 import MKLSparse.DSS: MatrixSymStructure, DSSError,
                       cholfact, ldltfact, lufact
 
@@ -32,7 +31,7 @@ for T in (Float32, Float64, Complex64, Complex128)
         @test_approx_eq At_ldiv_B(A, B) full(A.')\B
         @test_approx_eq Ac_ldiv_B(A, B) full(A')\B
 
-        for fact in (factorize, lufact, ldltfact, cholfact)
+        for fact in (factorize, MKLSparse.DSS.lufact, ldltfact, cholfact)
             # If factorization succeeds it should give correct answer.
             fact_failed = false
             F = 0.0 # To put F in scope... maybe better way to do this?

--- a/test/dss.jl
+++ b/test/dss.jl
@@ -34,7 +34,7 @@ for T in (Float32, Float64, Complex64, Complex128)
         for fact in (factorize, MKLSparse.DSS.lufact, ldltfact, cholfact)
             # If factorization succeeds it should give correct answer.
             fact_failed = false
-            F = 0.0 # To put F in scope... maybe better way to do this?
+            local F
             try
                 F = fact(A)
             catch e


### PR DESCRIPTION
As it is right now when `A*B` is used and `A` is sparse it is not actually the MKL routines that are running but the julia ones:

```julia
julia> @which sprand(1000,100,0.01) * rand(100)
*{TA,S,Tx}(A::Base.SparseMatrix.SparseMatrixCSC{TA,S}, 
x::Union{DenseArray{Tx,1},SubArray{Tx,1,A<:DenseArray{T,N},
I<:Tuple{Vararg{Union{Colon,Int64,Range{Int64}}}},LD}}) at sparse/linalg.jl:58
```

This means that the tests weren't testing the MKL routines. This PR adds method for `*` and `\` so when these are used the MKL routines are called instead of julia ones.

Also updated the README a little.