### PR TITLE
Widen alpha, beta type in mul! signature

### DIFF
--- a/src/BLAS/level_2_3/matmul.jl
+++ b/src/BLAS/level_2_3/matmul.jl
@@ -24,12 +24,12 @@ for (tchar, ttype) in (('N', :()),
                        ('T', :Transpose))
     AT = tchar == 'N' ? :(SparseMatrixCSC{$T,BlasInt}) : :($ttype{$T,SparseMatrixCSC{$T,BlasInt}})
     @eval begin
-        function mul!(C::$mat{$T}, adjA::$AT, B::$mat{$T}, α::$T, β::$T)
+        function mul!(C::$mat{$T}, adjA::$AT, B::$mat{$T}, α::Number, β::Number)
             A = _unwrap_adj(adjA)
             if isa(B, AbstractVector)
-                return cscmv!($tchar, α, matdescra(A), A, B, β, C)
+                return cscmv!($tchar, $T(α), matdescra(A), A, B, $T(β), C)
             else
-                return cscmm!($tchar, α, matdescra(A), A, B, β, C)
+                return cscmm!($tchar, $T(α), matdescra(A), A, B, $T(β), C)
             end
         end
 
@@ -50,12 +50,12 @@ for (tchar, ttype) in (('N', :()),
             :($w{$T,SparseMatrixCSC{$T,BlasInt}}) :
             :($ttype{$T,$w{$T,SparseMatrixCSC{$T,BlasInt}}})
         @eval begin
-            function mul!(C::$mat{$T}, adjA::$AT, B::$mat{$T}, α::$T, β::$T)
+            function mul!(C::$mat{$T}, adjA::$AT, B::$mat{$T}, α::Number, β::Number)
                 A = _unwrap_adj(adjA)
                 if isa(B,AbstractVector)
-                    return cscmv!($tchar, α, matdescra(A), _get_data(A), B, β, C)
+                    return cscmv!($tchar, $T(α), matdescra(A), _get_data(A), B, $T(β), C)
                 else
-                    return cscmm!($tchar, α, matdescra(A), _get_data(A), B, β, C)
+                    return cscmm!($tchar, $T(α), matdescra(A), _get_data(A), B, $T(β), C)
                 end
             end
 
@@ -73,13 +73,13 @@ for (tchar, ttype) in (('N', :()),
 
         if w != :Symmetric
             @eval begin
-                function ldiv!(α::$T, adjA::$AT,
+                function ldiv!(α::Number, adjA::$AT,
                                B::$mat{$T}, C::$mat{$T})
                     A = _unwrap_adj(adjA)
                     if isa(B,AbstractVector)
-                        return cscsv!($tchar, α, matdescra(A), _get_data(A), B, C)
+                        return cscsv!($tchar, $T(α), matdescra(A), _get_data(A), B, C)
                     else
-                        return cscsm!($tchar, α, matdescra(A), _get_data(A), B, C)
+                        return cscsm!($tchar, $T(α), matdescra(A), _get_data(A), B, C)
                     end
                 end
 

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -66,6 +66,10 @@ end
         @test_blas (maximum(abs.(mul!(copy(b), a, b, α, β) - (α*(Array(a)*b) + β*b))) < 100*eps())
         @test_blas (maximum(abs.(mul!(copy(b), transpose(a), b, α, β) - (α*(transpose(Array(a))*b) + β*b))) < 100*eps())
         @test_blas (maximum(abs.(mul!(copy(c), transpose(a), c, α, β) - (α*(transpose(Array(a))*c) + β*c))) < 100*eps())
+        α = β = 1 # test conversion to float
+        @test_blas (maximum(abs.(mul!(copy(b), a, b, α, β) - (α*(Array(a)*b) + β*b))) < 100*eps())
+        @test_blas (maximum(abs.(mul!(copy(b), transpose(a), b, α, β) - (α*(transpose(Array(a))*b) + β*b))) < 100*eps())
+        @test_blas (maximum(abs.(mul!(copy(c), transpose(a), c, α, β) - (α*(transpose(Array(a))*c) + β*c))) < 100*eps())
 
         c = randn(6) + im*randn(6)
         @test_throws DimensionMismatch transpose(a)*c


### PR DESCRIPTION
Currently, `mul!(C,A,B,α,β)` enforces `α` and `β` to be of the same type as the eltype of `C`, `A` and `B`. That's wholly unnecessary, and can easily cause an undesired dispatch to LinearAlgebra methods. This relaxes this constraint.