### PR TITLE
Cleanup Wrappers and Tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,19 @@
 name: ci
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+      - release-*
+      - runci/*
+    tags: ['*']
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,16 +32,11 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - name: Cache artifacts
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
+          show-versioninfo: true
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
         with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+          file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ julia = "1.6"
 MKL_jll = "2024.2.0"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/src/MKLSparse.jl
+++ b/src/MKLSparse.jl
@@ -4,8 +4,14 @@ using LinearAlgebra, SparseArrays
 using LinearAlgebra: BlasInt, BlasFloat, checksquare
 using MKL_jll: libmkl_rt
 
-# For testing purposes:
-global const __counter = Ref(0)
+# counts total MKL Sparse API calls (for testing purposes)
+global const __mklsparse_calls_count = Ref(0)
+
+# increments to the `__mklsparse_calls_count` variable
+function _log_mklsparse_call(fname)
+    #@debug "$fname called"
+    __mklsparse_calls_count[] += 1
+end
 
 @enum Threading begin
     THREADING_INTEL

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -18,7 +18,7 @@ function _check_transa(t::Char)
 end
 
 mkl_size(t::Char, M::AbstractVecOrMat) = t == 'N' ? size(M) : reverse(size(M))
-
+mkl_size(t::Char, M::AbstractVecOrMat, ix::Integer) = t == 'N' ? size(M, ix) : size(M, ndims(M) - ix + 1)
 
 # Checks sizes for the multiplication C <- A * B
 function _check_mat_mult_matvec(C, A, B, tA)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -16,7 +16,8 @@ function cscmv!(transa::Char, α::T, matdescra::String,
                 β::T, y::StridedVector{T}) where {T <: BlasFloat}
     check_transa(transa)
     check_mat_op_sizes(y, A, transa, x, 'N')
-    __counter[] += 1
+    _log_mklsparse_call(:mkl_Tcscmv)
+
     T == Float32    && (mkl_scscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
     T == Float64    && (mkl_dcscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
     T == ComplexF32 && (mkl_ccscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
@@ -31,7 +32,7 @@ function cscmm!(transa::Char, α::T, matdescra::String,
     check_mat_op_sizes(C, A, transa, B, 'N')
     mB, nB = size(B)
     mC, nC = size(C)
-    __counter[] += 1
+    _log_mklsparse_call(:mkl_Tcscmm)
 
     T == Float32    && (mkl_scscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
     T == Float64    && (mkl_dcscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
@@ -46,7 +47,7 @@ function cscsv!(transa::Char, α::T, matdescra::String,
     n = checksquare(A)
     check_transa(transa)
     check_mat_op_sizes(y, A, transa, x, 'N')
-    __counter[] += 1
+    _log_mklsparse_call(:mkl_Tcscsv)
 
     T == Float32    && (mkl_scscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
     T == Float64    && (mkl_dcscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
@@ -63,7 +64,7 @@ function cscsm!(transa::Char, α::T, matdescra::String,
     n = checksquare(A)
     check_transa(transa)
     check_mat_op_sizes(C, A, transa, B, 'N')
-    __counter[] += 1
+    _log_mklsparse_call(:mkl_Tcscsm)
 
     T == Float32    && (mkl_scscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))
     T == Float64    && (mkl_dcscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -5,7 +5,7 @@ matdescra(A::UnitLowerTriangular) = "TLUF"
 matdescra(A::UnitUpperTriangular) = "TUUF"
 matdescra(A::Symmetric) = string('S', A.uplo, 'N', 'F')
 matdescra(A::Hermitian) = string('H', A.uplo, 'N', 'F')
-matdescra(A::SparseMatrixCSC) = "GUUF"
+matdescra(A::SparseMatrixCSC) = "GFNF"
 matdescra(A::Transpose) = matdescra(A.parent)
 matdescra(A::Adjoint) = matdescra(A.parent)
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -11,38 +11,11 @@ matdescra(A::Adjoint) = matdescra(A.parent)
 
 # The increments to the `__counter` variable is for testing purposes
 
-function _check_transa(t::Char)
-    if !(t in ('C', 'N', 'T'))
-        error("transa: is '$t', must be 'N', 'T', or 'C'")
-    end
-end
-
-mkl_size(t::Char, M::AbstractVecOrMat) = t == 'N' ? size(M) : reverse(size(M))
-mkl_size(t::Char, M::AbstractVecOrMat, ix::Integer) = t == 'N' ? size(M, ix) : size(M, ndims(M) - ix + 1)
-
-# Checks sizes for the multiplication C <- A * B
-function _check_mat_mult_matvec(C, A, B, tA)
-    _size(v::AbstractMatrix) = size(v)
-    _size(v::AbstractVector) = (size(v,1), 1)
-    _str(v::AbstractMatrix) = string("[", size(v,1), ", ", size(v,2), "]")
-    _str(v::AbstractVector) = string("[", size(v,1), "]")
-    mA, nA = mkl_size(tA, A)
-    mB, nB = _size(B)
-    mC, nC = _size(C)
-    if nA != mB || mC != mA || nC != nB
-        t = ""
-        if tA == 'T'; t = ".\'"; end
-        if tA == 'C'; t = "\'"; end
-        str = string("arrays had inconsistent dimensions for C <- A", t, " * B: ", _str(C), " <- ", _str(A), t, " * ", _str(B))
-        throw(DimensionMismatch(str))
-    end
-end
-
 function cscmv!(transa::Char, α::T, matdescra::String,
                 A::SparseMatrixCSC{T, Int32}, x::StridedVector{T},
                 β::T, y::StridedVector{T}) where {T <: BlasFloat}
-    _check_transa(transa)
-    _check_mat_mult_matvec(y, A, x, transa)
+    check_transa(transa)
+    check_mat_op_sizes(y, A, transa, x, 'N')
     __counter[] += 1
     T == Float32    && (mkl_scscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
     T == Float64    && (mkl_dcscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
@@ -54,11 +27,12 @@ end
 function cscmm!(transa::Char, α::T, matdescra::String,
                 A::SparseMatrixCSC{T, Int32}, B::StridedMatrix{T},
                 β::T, C::StridedMatrix{T}) where {T <: BlasFloat}
-    _check_transa(transa)
-    _check_mat_mult_matvec(C, A, B, transa)
+    check_transa(transa)
+    check_mat_op_sizes(C, A, transa, B, 'N')
     mB, nB = size(B)
     mC, nC = size(C)
     __counter[] += 1
+
     T == Float32    && (mkl_scscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
     T == Float64    && (mkl_dcscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
     T == ComplexF32 && (mkl_ccscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
@@ -70,9 +44,10 @@ function cscsv!(transa::Char, α::T, matdescra::String,
                 A::SparseMatrixCSC{T, Int32}, x::StridedVector{T},
                 y::StridedVector{T}) where {T <: BlasFloat}
     n = checksquare(A)
-    _check_transa(transa)
-    _check_mat_mult_matvec(y, A, x, transa)
+    check_transa(transa)
+    check_mat_op_sizes(y, A, transa, x, 'N')
     __counter[] += 1
+
     T == Float32    && (mkl_scscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
     T == Float64    && (mkl_dcscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
     T == ComplexF32 && (mkl_ccscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
@@ -86,9 +61,10 @@ function cscsm!(transa::Char, α::T, matdescra::String,
     mB, nB = size(B)
     mC, nC = size(C)
     n = checksquare(A)
-    _check_transa(transa)
-    _check_mat_mult_matvec(C, A, B, transa)
+    check_transa(transa)
+    check_mat_op_sizes(C, A, transa, B, 'N')
     __counter[] += 1
+
     T == Float32    && (mkl_scscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))
     T == Float64    && (mkl_dcscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))
     T == ComplexF32 && (mkl_ccscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -9,66 +9,56 @@ matdescra(A::SparseMatrixCSC) = "GFNF"
 matdescra(A::Transpose) = matdescra(A.parent)
 matdescra(A::Adjoint) = matdescra(A.parent)
 
-# The increments to the `__counter` variable is for testing purposes
-
 function cscmv!(transa::Char, α::T, matdescra::String,
-                A::SparseMatrixCSC{T, Int32}, x::StridedVector{T},
+                A::AbstractSparseMatrix{T}, x::StridedVector{T},
                 β::T, y::StridedVector{T}) where {T <: BlasFloat}
     check_transa(transa)
     check_mat_op_sizes(y, A, transa, x, 'N')
-    _log_mklsparse_call(:mkl_Tcscmv)
 
-    T == Float32    && (mkl_scscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
-    T == Float64    && (mkl_dcscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
-    T == ComplexF32 && (mkl_ccscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
-    T == ComplexF64 && (mkl_zcscmv(transa, A.m, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y))
+    mkl_call(Val{:mkl_TSmvI}(), typeof(A),
+             transa, A.m, A.n, α, matdescra,
+             A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, β, y)
     return y
 end
 
 function cscmm!(transa::Char, α::T, matdescra::String,
-                A::SparseMatrixCSC{T, Int32}, B::StridedMatrix{T},
+                A::SparseMatrixCSC{T}, B::StridedMatrix{T},
                 β::T, C::StridedMatrix{T}) where {T <: BlasFloat}
     check_transa(transa)
     check_mat_op_sizes(C, A, transa, B, 'N')
     mB, nB = size(B)
     mC, nC = size(C)
-    _log_mklsparse_call(:mkl_Tcscmm)
 
-    T == Float32    && (mkl_scscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
-    T == Float64    && (mkl_dcscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
-    T == ComplexF32 && (mkl_ccscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
-    T == ComplexF64 && (mkl_zcscmm(transa, A.m, nC, A.n, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC))
+    mkl_call(Val{:mkl_TSmmI}(), typeof(A),
+             transa, A.m, nC, A.n, α, matdescra,
+             A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, β, C, mC)
     return C
 end
 
 function cscsv!(transa::Char, α::T, matdescra::String,
-                A::SparseMatrixCSC{T, Int32}, x::StridedVector{T},
+                A::SparseMatrixCSC{T}, x::StridedVector{T},
                 y::StridedVector{T}) where {T <: BlasFloat}
     n = checksquare(A)
     check_transa(transa)
     check_mat_op_sizes(y, A, transa, x, 'N')
-    _log_mklsparse_call(:mkl_Tcscsv)
 
-    T == Float32    && (mkl_scscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
-    T == Float64    && (mkl_dcscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
-    T == ComplexF32 && (mkl_ccscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
-    T == ComplexF64 && (mkl_zcscsv(transa, A.m, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y))
+    mkl_call(Val{:mkl_TSsvI}(), typeof(A),
+             transa, A.m, α, matdescra,
+             A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), x, y)
     return y
 end
 
 function cscsm!(transa::Char, α::T, matdescra::String,
-                A::SparseMatrixCSC{T, Int32}, B::StridedMatrix{T},
+                A::SparseMatrixCSC{T}, B::StridedMatrix{T},
                 C::StridedMatrix{T}) where {T <: BlasFloat}
     mB, nB = size(B)
     mC, nC = size(C)
     n = checksquare(A)
     check_transa(transa)
     check_mat_op_sizes(C, A, transa, B, 'N')
-    _log_mklsparse_call(:mkl_Tcscsm)
 
-    T == Float32    && (mkl_scscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))
-    T == Float64    && (mkl_dcscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))
-    T == ComplexF32 && (mkl_ccscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))
-    T == ComplexF64 && (mkl_zcscsm(transa, A.n, nC, α, matdescra, A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC))
+    mkl_call(Val{:mkl_TSsmI}(), typeof(A),
+             transa, A.n, nC, α, matdescra,
+             A.nzval, A.rowval, A.colptr, pointer(A.colptr, 2), B, mB, C, mC)
     return C
 end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -12,7 +12,7 @@ for T in (:Float32, :Float64, :ComplexF32, :ComplexF64)
         function mv!(transa::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedVector{$T}, beta::$T, y::StridedVector{$T})
           check_transa(transa)
           check_mat_op_sizes(y, A, transa, x, 'N')
-          __counter[] += 1
+          _log_mklsparse_call($fname_mv)
           $fname_mv(transa, alpha, MKLSparseMatrix(A), descr, x, beta, y)
           return y
         end
@@ -20,7 +20,7 @@ for T in (:Float32, :Float64, :ComplexF32, :ComplexF64)
         function mm!(transa::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedMatrix{$T}, beta::$T, y::StridedMatrix{$T})
           check_transa(transa)
           check_mat_op_sizes(y, A, transa, x, 'N')
-          __counter[] += 1
+          _log_mklsparse_call($fname_mm)
           columns = size(y, 2)
           ldx = stride(x, 2)
           ldy = stride(y, 2)
@@ -32,7 +32,7 @@ for T in (:Float32, :Float64, :ComplexF32, :ComplexF64)
           checksquare(A)
           check_transa(transa)
           check_mat_op_sizes(y, A, transa, x, 'N')
-          __counter[] += 1
+          _log_mklsparse_call($fname_trsv)
           $fname_trsv(transa, alpha, MKLSparseMatrix(A), descr, x, y)
           return y
         end
@@ -41,7 +41,7 @@ for T in (:Float32, :Float64, :ComplexF32, :ComplexF64)
           checksquare(A)
           check_transa(transa)
           check_mat_op_sizes(y, A, transa, x, 'N')
-          __counter[] += 1
+          _log_mklsparse_call($fname_trsm)
           columns = size(y, 2)
           ldx = stride(x, 2)
           ldy = stride(y, 2)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -9,43 +9,43 @@ for T in (:Float32, :Float64, :ComplexF32, :ComplexF64)
       fname_trsm = Symbol("mkl_sparse_", mkl_type_specifier(T), "_trsm", mkl_integer_specifier(INT))
 
       @eval begin
-        function mv!(operation::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedVector{$T}, beta::$T, y::StridedVector{$T})
-          _check_transa(operation)
-          _check_mat_mult_matvec(y, A, x, operation)
+        function mv!(transa::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedVector{$T}, beta::$T, y::StridedVector{$T})
+          check_transa(transa)
+          check_mat_op_sizes(y, A, transa, x, 'N')
           __counter[] += 1
-          $fname_mv(operation, alpha, MKLSparseMatrix(A), descr, x, beta, y)
+          $fname_mv(transa, alpha, MKLSparseMatrix(A), descr, x, beta, y)
           return y
         end
 
-        function mm!(operation::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedMatrix{$T}, beta::$T, y::StridedMatrix{$T})
-          _check_transa(operation)
-          _check_mat_mult_matvec(y, A, x, operation)
+        function mm!(transa::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedMatrix{$T}, beta::$T, y::StridedMatrix{$T})
+          check_transa(transa)
+          check_mat_op_sizes(y, A, transa, x, 'N')
           __counter[] += 1
           columns = size(y, 2)
           ldx = stride(x, 2)
           ldy = stride(y, 2)
-          $fname_mm(operation, alpha, MKLSparseMatrix(A), descr, 'C', x, columns, ldx, beta, y, ldy)
+          $fname_mm(transa, alpha, MKLSparseMatrix(A), descr, 'C', x, columns, ldx, beta, y, ldy)
           return y
         end
 
-        function trsv!(operation::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedVector{$T}, y::StridedVector{$T})
+        function trsv!(transa::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedVector{$T}, y::StridedVector{$T})
           checksquare(A)
-          _check_transa(operation)
-          _check_mat_mult_matvec(y, A, x, operation)
+          check_transa(transa)
+          check_mat_op_sizes(y, A, transa, x, 'N')
           __counter[] += 1
-          $fname_trsv(operation, alpha, MKLSparseMatrix(A), descr, x, y)
+          $fname_trsv(transa, alpha, MKLSparseMatrix(A), descr, x, y)
           return y
         end
 
-        function trsm!(operation::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedMatrix{$T}, y::StridedMatrix{$T})
+        function trsm!(transa::Char, alpha::$T, A::$SparseMatrix, descr::matrix_descr, x::StridedMatrix{$T}, y::StridedMatrix{$T})
           checksquare(A)
-          _check_transa(operation)
-          _check_mat_mult_matvec(y, A, x, operation)
+          check_transa(transa)
+          check_mat_op_sizes(y, A, transa, x, 'N')
           __counter[] += 1
           columns = size(y, 2)
           ldx = stride(x, 2)
           ldy = stride(y, 2)
-          $fname_trsm(operation, alpha, MKLSparseMatrix(A), descr, 'C', x, columns, ldx, y, ldy)
+          $fname_trsm(transa, alpha, MKLSparseMatrix(A), descr, 'C', x, columns, ldx, y, ldy)
           return y
         end
       end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -31,6 +31,13 @@ function mul!(C::StridedMatrix{T}, A::SimpleOrSpecialOrAdjMat{T, S}, B::StridedM
     mm!(transA, T(alpha), unwrapA, descrA, B, T(beta), C)
 end
 
+# 3-arg mul!() calls 5-arg mul!()
+mul!(C::StridedMatrix{T}, A::SimpleOrSpecialOrAdjMat{T, S}, B::StridedMatrix{T}) where {T <: BlasFloat, S <: MKLSparseMat{T}} =
+    mul!(C, A, B, one(T), zero(T))
+mul!(y::StridedVector{T}, A::SimpleOrSpecialOrAdjMat{T, S}, x::StridedVector{T}) where {T <: BlasFloat, S <: MKLSparseMat{T}} =
+    mul!(y, A, x, one(T), zero(T))
+
+
 # define 4-arg ldiv!(C, A, B, a) (C := alpha*inv(A)*B) that is not present in standard LinearAlgrebra
 # redefine 3-arg ldiv!(C, A, B) using 4-arg ldiv!(C, A, B, 1)
 function ldiv!(y::StridedVector{T}, A::SimpleOrSpecialOrAdjMat{T, S}, x::StridedVector{T}, alpha::Number = one(T)) where {T <: BlasFloat, S <: MKLSparseMat{T}}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -49,14 +49,16 @@ for T in (:Float32, :Float64, :ComplexF32, :ComplexF64)
               return mm!($transa, $T(alpha), $(untrianglea(unwrapa(:A))), $matrixdescra(A), B, $T(beta), C)
           end
 
-          function LinearAlgebra.ldiv!(y::StridedVector{$T}, A::$TypeA, x::StridedVector{$T})
-            # return cscsv!($transa, one($T), $matdescra(A), $(untrianglea(unwrapa(:A))), x, y)
-            return trsv!($transa, one($T), $(untrianglea(unwrapa(:A))), $matrixdescra(A), x, y)
+          # define 4-arg ldiv!(C, A, B, a) (C := alpha*inv(A)*B) that is not present in standard LinearAlgrebra
+          # redefine 3-arg ldiv!(C, A, B) using 4-arg ldiv!(C, A, B, 1)
+          function LinearAlgebra.ldiv!(y::StridedVector{$T}, A::$TypeA, x::StridedVector{$T}, alpha::Number = one($T))
+            # return cscsv!($transa, alpha, $matdescra(A), $(untrianglea(unwrapa(:A))), x, y)
+            return trsv!($transa, alpha, $(untrianglea(unwrapa(:A))), $matrixdescra(A), x, y)
           end
 
-          function LinearAlgebra.ldiv!(C::StridedMatrix{$T}, A::$TypeA, B::StridedMatrix{$T})
-            # return cscsm!($transa, one($T), $matdescra(A), $(untrianglea(unwrapa(:A))), B, C)
-            return trsm!($transa, one($T), $(untrianglea(unwrapa(:A))), $matrixdescra(A), B, C)
+          function LinearAlgebra.ldiv!(C::StridedMatrix{$T}, A::$TypeA, B::StridedMatrix{$T}, alpha::Number = one($T))
+            # return cscsm!($transa, alpha, $matdescra(A), $(untrianglea(unwrapa(:A))), B, C)
+            return trsm!($transa, alpha, $(untrianglea(unwrapa(:A))), $matrixdescra(A), B, C)
           end
 
           function (*)(A::$TypeA, x::StridedVector{$T})

--- a/src/types.jl
+++ b/src/types.jl
@@ -51,7 +51,7 @@ matrixdescra(A::SparseMatrixCSC)     = matrix_descr('G', 'F', 'N')
 matrixdescra(A::Transpose)           = matrixdescra(A.parent)
 matrixdescra(A::Adjoint)             = matrixdescra(A.parent)
 
-function Base.convert(::Type{sparse_operation_t}, trans::Char)
+@inline function Base.convert(::Type{sparse_operation_t}, trans::Char)
     if trans == 'N'
         SPARSE_OPERATION_NON_TRANSPOSE
     elseif trans == 'T'
@@ -63,7 +63,7 @@ function Base.convert(::Type{sparse_operation_t}, trans::Char)
     end
 end
 
-function Base.convert(::Type{sparse_matrix_type_t}, mattype::Char)
+@inline function Base.convert(::Type{sparse_matrix_type_t}, mattype::Char)
     if mattype == 'G'
         SPARSE_MATRIX_TYPE_GENERAL
     elseif mattype == 'S'
@@ -79,7 +79,7 @@ function Base.convert(::Type{sparse_matrix_type_t}, mattype::Char)
     end
 end
 
-function Base.convert(::Type{sparse_matrix_type_t}, mattype::String)
+@inline function Base.convert(::Type{sparse_matrix_type_t}, mattype::String)
     if length(mattype) == 1
         return convert(sparse_matrix_type_t, mattype[1])
     elseif mattype == "BT"
@@ -91,7 +91,7 @@ function Base.convert(::Type{sparse_matrix_type_t}, mattype::String)
     end
 end
 
-function Base.convert(::Type{sparse_index_base_t}, index::Char)
+@inline function Base.convert(::Type{sparse_index_base_t}, index::Char)
     if index == 'Z'
         return SPARSE_INDEX_BASE_ZERO
     elseif index == 'O'
@@ -101,7 +101,7 @@ function Base.convert(::Type{sparse_index_base_t}, index::Char)
     end
 end
 
-function Base.convert(::Type{sparse_fill_mode_t}, uplo::Char)
+@inline function Base.convert(::Type{sparse_fill_mode_t}, uplo::Char)
     if uplo == 'L'
         SPARSE_FILL_MODE_LOWER
     elseif uplo == 'U'
@@ -113,7 +113,7 @@ function Base.convert(::Type{sparse_fill_mode_t}, uplo::Char)
     end
 end
 
-function Base.convert(::Type{sparse_diag_type_t}, diag::Char)
+@inline function Base.convert(::Type{sparse_diag_type_t}, diag::Char)
     if diag == 'U'
         SPARSE_DIAG_UNIT
     elseif diag == 'N'
@@ -123,7 +123,7 @@ function Base.convert(::Type{sparse_diag_type_t}, diag::Char)
     end
 end
 
-function Base.convert(::Type{sparse_layout_t}, layout::Char)
+@inline function Base.convert(::Type{sparse_layout_t}, layout::Char)
     if layout == 'R'
         SPARSE_LAYOUT_ROW_MAJOR
     elseif layout == 'C'
@@ -133,7 +133,7 @@ function Base.convert(::Type{sparse_layout_t}, layout::Char)
     end
 end
 
-function Base.convert(::Type{verbose_mode_t}, verbose::String)
+@inline function Base.convert(::Type{verbose_mode_t}, verbose::String)
     if verbose == "off"
         SPARSE_VERBOSE_OFF
     elseif verbose == "basic"
@@ -145,7 +145,7 @@ function Base.convert(::Type{verbose_mode_t}, verbose::String)
     end
 end
 
-function Base.convert(::Type{sparse_memory_usage_t}, memory::String)
+@inline function Base.convert(::Type{sparse_memory_usage_t}, memory::String)
     if memory == "none"
         SPARSE_MEMORY_NONE
     elseif memory == "aggressive"
@@ -155,7 +155,7 @@ function Base.convert(::Type{sparse_memory_usage_t}, memory::String)
     end
 end
 
-Base.convert(::Type{matrix_descr}, matdescr::AbstractString) =
+@inline Base.convert(::Type{matrix_descr}, matdescr::AbstractString) =
     matrix_descr(convert(sparse_matrix_type_t, matdescr[1]),
                  convert(sparse_fill_mode_t, matdescr[2]),
                  convert(sparse_diag_type_t, matdescr[3]))

--- a/src/types.jl
+++ b/src/types.jl
@@ -138,3 +138,8 @@ function Base.convert(::Type{sparse_memory_usage_t}, memory::String)
         throw(ArgumentError("Unknown memory usage $memory"))
     end
 end
+
+Base.convert(::Type{matrix_descr}, matdescr::AbstractString) =
+    matrix_descr(convert(sparse_matrix_type_t, matdescr[1]),
+                 convert(sparse_fill_mode_t, matdescr[2]),
+                 convert(sparse_diag_type_t, matdescr[3]))

--- a/src/types.jl
+++ b/src/types.jl
@@ -64,20 +64,12 @@ function Base.convert(::Type{sparse_matrix_type_t}, mattype::Char)
 end
 
 function Base.convert(::Type{sparse_matrix_type_t}, mattype::String)
-    if mattype == "G"
-        SPARSE_MATRIX_TYPE_GENERAL
-    elseif mattype == "S"
-        SPARSE_MATRIX_TYPE_SYMMETRIC
-    elseif mattype == "H"
-        SPARSE_MATRIX_TYPE_HERMITIAN
-    elseif mattype == "T"
-        SPARSE_MATRIX_TYPE_TRIANGULAR
-    elseif mattype == "D"
-        SPARSE_MATRIX_TYPE_DIAGONAL
+    if length(mattype) == 1
+        return convert(sparse_matrix_type_t, mattype[1])
     elseif mattype == "BT"
-        SPARSE_MATRIX_TYPE_BLOCK_TRIANGULAR
+        return SPARSE_MATRIX_TYPE_BLOCK_TRIANGULAR
     elseif mattype == "BD"
-        SPARSE_MATRIX_TYPE_BLOCK_DIAGONAL
+        return SPARSE_MATRIX_TYPE_BLOCK_DIAGONAL
     else
         throw(ArgumentError("Unknown matrix type $mattype"))
     end

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -39,9 +39,9 @@ end
 macro blas(ex)
     quote
         begin
-            MKLSparse.__counter[] = 0
+            MKLSparse.__mklsparse_calls_count[] = 0
             local res = $(@inferred(esc(ex)))
-            @test MKLSparse.__counter[] == 1
+            @test MKLSparse.__mklsparse_calls_count[] == 1
             res
         end
     end

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -177,7 +177,7 @@ end
         spAclass = Aclass(spA)
         α = rand(T)
 
-        @test @blas(ldiv!(α, Aclass(spA), B, similar(B))) ≈ α * (Aclass(A) \ B)
+        @test @blas(ldiv!(similar(B), Aclass(spA), B, α)) ≈ α * (Aclass(A) \ B)
         @test @blas(ldiv!(similar(B), Aclass(spA), B)) ≈ Aclass(A) \ B
         @test @blas(Aclass(spA) \ B) ≈ Aclass(A) \ B
     end

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -1,7 +1,9 @@
 using MKLSparse
-using Test, SparseArrays, LinearAlgebra
+using Test, Random, SparseArrays, LinearAlgebra
 
 @testset "MKLSparse.matdescra()" begin
+    Random.seed!(100500)
+
     sA = sprand(5, 5, 0.01)
     sS = sA'sA
     sTl = tril(sS)
@@ -63,6 +65,8 @@ matrix_classes = [
 local atol::real(T) = 100*eps(real(one(T))) # absolute tolerance for SparseBLAS results
 
 @testset "SparseMatrixCSC{$T,$IT} * Vector{$T}" begin
+    Random.seed!(100500)
+
     for _ in 1:10
         spA = convert(SpraseMatrixCSC{T, IT}, sprand(T, 10, 5, 0.5))
         a = Array(spA)
@@ -80,6 +84,8 @@ local atol::real(T) = 100*eps(real(one(T))) # absolute tolerance for SparseBLAS 
 end
 
 @testset "Vector{$T} * SparseMatrixCSC{$T,$IT}" begin
+    Random.seed!(100500)
+
     for _ in 1:10
         spA = convert(SparseMatrixCSC{T, IT}, sprand(T, 10, 5, 0.5))
         a = Array(spA)
@@ -104,6 +110,8 @@ end
 end
 
 @testset "SparseMatrixCSC{$T,$IT} * Matrix{$T}" begin
+    Random.seed!(100500)
+
     for _ in 1:10
         spA = convert(SparseMatrixCSC{T,IT}, sprand(T, 10, 5, 0.5))
         a = Array(spA)
@@ -138,6 +146,8 @@ end
 
 @testset "$Aclass{SparseMatrixCSC{$T}} * $(ifelse(Bdim == 2, "Matrix", "Vector")){$T}" for Bdim in 1:2,
         (Aclass, convert_to_class) in matrix_classes
+    Random.seed!(100500)
+
     for _ in 1:10
         n = rand(50:150)
         spA = convert_to_class(sprand(T, n, n, 0.5) + convert(real(T), sqrt(n))*I)
@@ -156,6 +166,8 @@ end
     (Aclass, convert_to_class) in matrix_classes
 
     (Aclass == Symmetric || Aclass == Hermitian) && continue # not implemented in MKLSparse
+
+    Random.seed!(100500)
 
     for _ in 1:10
         n = rand(50:150)

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -125,6 +125,7 @@ end
         n = rand(50:150)
         spA = convert_to_class(sprand(T, n, n, 0.5) + convert(real(T), sqrt(n))*I)
         A = Array(spA)
+        @test spA == A
         B = Bdim == 2 ? rand(T, n, n) : rand(T, n)
         α = rand(T)
 

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -28,102 +28,121 @@ macro blas(ex)
     end
 end
 
-for T in (Float64, ComplexF64)
-  INT_TYPES = Base.USE_BLAS64 ? (Int32, Int64) : (Int32,)
-  for INT in INT_TYPES
-        @testset "matrix-vector and matrix-matrix multiplications (non-square) -- $T -- $INT" begin
-            for i = 1:5
-                A = sprand(T, 10, 5, 0.5)
-                A = SparseMatrixCSC{T,INT}(A)
-                b = rand(T, 5)
-                @test @blas(A*b) ≈ Array(A)*b
-                B = rand(T, 5, 5)
-                @test @blas(A*B) ≈ Array(A)*B
-                b = rand(T, 10)
-                @test @blas(A'*b) ≈ Array(A)'*b
-                @test @blas(transpose(A)*b) ≈ transpose(Array(A))*b
-                B = rand(T, 10, 10)
-                @test @blas(A'*B) ≈ Array(A)'*B
-                @test @blas(transpose(A)*B) ≈ transpose(Array(A))*B
-            end
-        end
+@testset "SparseBLAS for $T matrices and vectors and $IT indices" for
+    T in (Float32, Float64, ComplexF32, ComplexF64),
+    IT in (Base.USE_BLAS64 ? (Int32, Int64) : (Int32,))
 
-        @testset "Symmetric / Hermitian -- $T -- $INT" begin
-            n = 10
-            A = sprandn(T, n, n, 0.5) + sqrt(n)*I
-            A = SparseMatrixCSC{T,INT}(A)
-            b = rand(T, n)
-            B = rand(T, n, 3)
-            symA = A + transpose(A)
-            hermA = A + adjoint(A)
-            @test @blas(Symmetric(symA) * b) ≈ Array(Symmetric(symA)) * b
-            @test @blas(Hermitian(hermA) * b) ≈ Array(Hermitian(hermA)) * b
-            @test @blas(Symmetric(symA) * B) ≈ Array(Symmetric(symA)) * B
-            @test @blas(Hermitian(hermA) * B) ≈ Array(Hermitian(hermA)) * B
-        end
+local atol::real(T) = 100*eps(real(one(T))) # absolute tolerance for SparseBLAS results
 
-        @testset "triangular -- $T -- $INT" begin
-            n = 10
-            A = sprandn(T, n, n, 0.5) + sqrt(n)*I
-            A = SparseMatrixCSC{T,INT}(A)
-            b = rand(T, n)
-            B = rand(T, n, 3)
-            trilA = tril(A)
-            triuA = triu(A)
-            trilUA = tril(A, -1) + I
-            triuUA = triu(A, 1)  + I
+@testset "SparseMatrixCSC{$T,$IT} * Vector{$T}" begin
+    for _ in 1:10
+        spA = convert(SpraseMatrixCSC{T, IT}, sprand(T, 10, 5, 0.5))
+        a = Array(spA)
+        b = rand(T, 5)
+        c = rand(T, 10)
 
-            @test @blas(LowerTriangular(trilA) \ b) ≈ Array(LowerTriangular(trilA)) \ b
-            @test @blas(LowerTriangular(trilA) * b) ≈ Array(LowerTriangular(trilA)) * b
-            @test @blas(LowerTriangular(trilA) \ B) ≈ Array(LowerTriangular(trilA)) \ B
-            @test @blas(LowerTriangular(trilA) * B) ≈ Array(LowerTriangular(trilA)) * B
+        @test @blas(spA*b) ≈ a*b atol=atol
+        @test @blas(spA'*c) ≈ a'*c atol=atol
+        @test @blas(transpose(spA)*c) ≈ transpose(a)*c atol=atol
 
-            @test @blas(UpperTriangular(triuA) \ b) ≈ Array(UpperTriangular(triuA)) \ b
-            @test @blas(UpperTriangular(triuA) * b) ≈ Array(UpperTriangular(triuA)) * b
-            @test @blas(UpperTriangular(triuA) \ B) ≈ Array(UpperTriangular(triuA)) \ B
-            @test @blas(UpperTriangular(triuA) * B) ≈ Array(UpperTriangular(triuA)) * B
+        @test_throws DimensionMismatch spA*c
+        @test_throws DimensionMismatch spA'*b
+        @test_throws DimensionMismatch transpose(spA)*b
+    end
+end
 
-            @test @blas(UnitLowerTriangular(trilUA) \ b) ≈ Array(UnitLowerTriangular(trilUA)) \ b
-            @test @blas(UnitLowerTriangular(trilUA) * b) ≈ Array(UnitLowerTriangular(trilUA)) * b
-            @test @blas(UnitLowerTriangular(trilUA) \ B) ≈ Array(UnitLowerTriangular(trilUA)) \ B
-            @test @blas(UnitLowerTriangular(trilUA) * B) ≈ Array(UnitLowerTriangular(trilUA)) * B
+@testset "Vector{$T} * SparseMatrixCSC{$T,$IT}" begin
+    for _ in 1:10
+        spA = convert(SparseMatrixCSC{T, IT}, sprand(T, 10, 5, 0.5))
+        a = Array(spA)
+        b = rand(T, 10)
+        c = rand(T, 5)
 
-            @test @blas(UnitUpperTriangular(triuUA) \ b) ≈ Array(UnitUpperTriangular(triuUA)) \ b
-            @test @blas(UnitUpperTriangular(triuUA) * b) ≈ Array(UnitUpperTriangular(triuUA)) * b
-            @test @blas(UnitUpperTriangular(triuUA) \ B) ≈ Array(UnitUpperTriangular(triuUA)) \ B
-            @test @blas(UnitUpperTriangular(triuUA) * B) ≈ Array(UnitUpperTriangular(triuUA)) * B
+        @test @blas(b'*spA) ≈ b'*a atol=atol
+        @test @blas(c'*spA') ≈ c'*a' atol=atol
+
+        @test_throws DimensionMismatch c*spA
+        @test_throws DimensionMismatch b*spA'
+        @test_throws DimensionMismatch b*transpose(spA)
+
+        @test_throws DimensionMismatch c'*spA
+        @test_throws DimensionMismatch b'*spA'
+
+        if !(T <: Complex) # adjoint*transposed isn't routed to BLAS call
+            @test @blas(c'*transpose(spA)) ≈ c'*transpose(a) atol=atol
+            @test_throws DimensionMismatch b'*transpose(spA)
         end
     end
 end
 
-const atol = 100*eps() # absolute tolerance for SparseBLAS results
+@testset "SparseMatrixCSC{$T,$IT} * Matrix{$T}" begin
+    for _ in 1:10
+        spA = convert(SparseMatrixCSC{T,IT}, sprand(T, 10, 5, 0.5))
+        a = Array(spA)
+        b = rand(T, 5, 8)
+        c = rand(T, 10, 12)
+        ab = rand(T, 10, 8)
+        tac = rand(T, 5, 12)
+        α = rand(T)
+        β = rand(T)
 
-@testset "complex matrix-vector multiplication" begin
-    for i = 1:5
-        a = I + im * 0.1*sprandn(5, 5, 0.2)
-        b = randn(5,3) + im*randn(5,3)
-        c = randn(5) + im*randn(5)
-        d = randn(5) + im*randn(5)
-        α = rand(ComplexF64)
-        β = rand(ComplexF64)
-        @test @blas(a*b) ≈ Array(a)*b atol=atol
-        @test @blas(a'*b) ≈ Array(a)'*b atol=atol
-        @test @blas(transpose(a)*b) ≈ transpose(Array(a))*b atol=atol
-        @test @blas(mul!(similar(b), a, b)) ≈ Array(a)*b atol=atol
-        @test @blas(mul!(similar(c), a, c)) ≈ Array(a)*c atol=atol
-        @test @blas(mul!(similar(b), transpose(a), b)) ≈ transpose(Array(a))*b atol=atol
-        @test @blas(mul!(similar(c), transpose(a), c)) ≈ transpose(Array(a))*c atol=atol
-        @test @blas(mul!(copy(b), a, b, α, β)) ≈ (α*(Array(a)*b) + β*b) atol=atol
-        @test @blas(mul!(copy(b), transpose(a), b, α, β)) ≈ (α*(transpose(Array(a))*b) + β*b) atol=atol
-        @test @blas(mul!(copy(c), transpose(a), c, α, β)) ≈ (α*(transpose(Array(a))*c) + β*c) atol=atol
-        α = β = 1 # test conversion to float
-        @test @blas(mul!(copy(b), a, b, α, β)) ≈ (α*(Array(a)*b) + β*b) atol=atol
-        @test @blas(mul!(copy(b), transpose(a), b, α, β)) ≈ (α*(transpose(Array(a))*b) + β*b) atol=atol
-        @test @blas(mul!(copy(c), transpose(a), c, α, β)) ≈ (α*(transpose(Array(a))*c) + β*c) atol=atol
+        @test @blas(spA*b) ≈ a*b atol=atol
+        @test @blas(spA'*c) ≈ a'*c atol=atol
+        @test @blas(transpose(spA)*c) ≈ transpose(a)*c atol=atol
 
-        c = randn(6) + im*randn(6)
-        @test_throws DimensionMismatch transpose(a)*c
-        @test_throws DimensionMismatch a.*c
-        @test_throws DimensionMismatch a.*c
+        @test_throws DimensionMismatch spA*c
+        @test_throws DimensionMismatch spA'*b
+        @test_throws DimensionMismatch transpose(spA)*b
+
+        @test @blas(mul!(similar(ab), spA, b)) ≈ a*b atol=atol
+        @test @blas(mul!(similar(tac), spA', c)) ≈ a'*c atol=atol
+        @test @blas(mul!(similar(tac), transpose(spA), c)) ≈ transpose(a)*c atol=atol
+
+        @test @blas(mul!(copy(ab), spA, b, α, β)) ≈ α*a*b + β*ab atol=atol
+        @test @blas(mul!(copy(tac), spA', c, α, β)) ≈ α*a'*c + β*tac atol=atol
+        @test @blas(mul!(copy(tac), transpose(spA), c, α, β)) ≈ α*transpose(a)*c + β*tac atol=atol
+
+        @test @blas(mul!(copy(ab), spA, b, 1, 1)) ≈ a*b + ab atol=atol
+        @test @blas(mul!(copy(tac), transpose(spA), c, 1, 1)) ≈ transpose(a)*c + tac atol=atol
+        @test @blas(mul!(copy(tac), spA', c, 1, 1)) ≈ a'*c + tac atol=atol
+
+        symA = spA + transpose(spA)
+        @test @blas(Symmetric(symA) * b) ≈ Array(Symmetric(symA)) * b
+        hermA = spA + adjoint(spA)
+        @test @blas(Hermitian(hermA) * b) ≈ Array(Hermitian(hermA)) * b
     end
 end
+
+@testset "SparseMatrixCSC{$T, $IT} {* /} Vector{$T} for triangular/symmetric/hermitian" begin
+    for _ in 1:10
+        n = rand(50:150)
+        spA = convert(SparseMatrixCSC{T, IT}, sprand(T, n, n, 0.5) + convert(real(T), sqrt(n))*I)
+        A = Array(spA)
+        b = rand(T, n)
+
+        trilA = tril(spA)
+        @test @blas(LowerTriangular(trilA) \ b) ≈ Array(LowerTriangular(trilA)) \ b
+        @test @blas(LowerTriangular(trilA) * b) ≈ Array(LowerTriangular(trilA)) * b
+
+        triuA = triu(spA)
+        @test @blas(UpperTriangular(triuA) \ b) ≈ Array(UpperTriangular(triuA)) \ b
+        @test @blas(UpperTriangular(triuA) * b) ≈ Array(UpperTriangular(triuA)) * b
+
+        trilUA = tril(spA, -1) + I
+        @test @blas(UnitLowerTriangular(trilUA) \ b) ≈ Array(UnitLowerTriangular(trilUA)) \ b
+        @test @blas(UnitLowerTriangular(trilUA) * b) ≈ Array(UnitLowerTriangular(trilUA)) * b
+
+        triuUA = triu(spA, 1)  + I
+        @test @blas(UnitUpperTriangular(triuUA) \ b) ≈ Array(UnitUpperTriangular(triuUA)) \ b
+        @test @blas(UnitUpperTriangular(triuUA) * b) ≈ Array(UnitUpperTriangular(triuUA)) * b
+
+        symA = spA + transpose(spA)
+        @test @blas(Symmetric(symA) * b) ≈ Array(Symmetric(symA)) * b
+
+        hermA = spA + adjoint(spA)
+        @test @blas(Hermitian(hermA) * b) ≈ Array(Hermitian(hermA)) * b
+    end
+end
+
+end
+

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -16,6 +16,23 @@ using Test, SparseArrays, LinearAlgebra
     @test MKLSparse.matdescra(sA) == "GFNF"
 end
 
+@testset "convert(MKLSparse.matrix_descr, matdescr::AbstractString)" begin
+    @test convert(MKLSparse.matrix_descr, "SLNF") == MKLSparse.matrix_descr(
+        MKLSparse.SPARSE_MATRIX_TYPE_SYMMETRIC, MKLSparse.SPARSE_FILL_MODE_LOWER, MKLSparse.SPARSE_DIAG_NON_UNIT)
+    @test convert(MKLSparse.matrix_descr, "SUNF") == MKLSparse.matrix_descr(
+            MKLSparse.SPARSE_MATRIX_TYPE_SYMMETRIC, MKLSparse.SPARSE_FILL_MODE_UPPER, MKLSparse.SPARSE_DIAG_NON_UNIT)
+    @test convert(MKLSparse.matrix_descr, "TLNF") == MKLSparse.matrix_descr(
+        MKLSparse.SPARSE_MATRIX_TYPE_TRIANGULAR, MKLSparse.SPARSE_FILL_MODE_LOWER, MKLSparse.SPARSE_DIAG_NON_UNIT)
+    @test convert(MKLSparse.matrix_descr, "TUNF") == MKLSparse.matrix_descr(
+        MKLSparse.SPARSE_MATRIX_TYPE_TRIANGULAR, MKLSparse.SPARSE_FILL_MODE_UPPER, MKLSparse.SPARSE_DIAG_NON_UNIT)
+    @test convert(MKLSparse.matrix_descr, "TLUF") == MKLSparse.matrix_descr(
+        MKLSparse.SPARSE_MATRIX_TYPE_TRIANGULAR, MKLSparse.SPARSE_FILL_MODE_LOWER, MKLSparse.SPARSE_DIAG_UNIT)
+    @test convert(MKLSparse.matrix_descr, "TUUF") == MKLSparse.matrix_descr(
+        MKLSparse.SPARSE_MATRIX_TYPE_TRIANGULAR, MKLSparse.SPARSE_FILL_MODE_UPPER, MKLSparse.SPARSE_DIAG_UNIT)
+    @test convert(MKLSparse.matrix_descr, "GFNF") == MKLSparse.matrix_descr(
+        MKLSparse.SPARSE_MATRIX_TYPE_GENERAL, MKLSparse.SPARSE_FILL_MODE_FULL, MKLSparse.SPARSE_DIAG_NON_UNIT)
+end
+
 # evaluates ex and checks whether it has called any SparseBLAS MKL method
 macro blas(ex)
     quote

--- a/test/test_BLAS.jl
+++ b/test/test_BLAS.jl
@@ -13,7 +13,7 @@ using Test, SparseArrays, LinearAlgebra
     @test MKLSparse.matdescra(UpperTriangular(sTu)) == "TUNF"
     @test MKLSparse.matdescra(UnitLowerTriangular(sTl)) == "TLUF"
     @test MKLSparse.matdescra(UnitUpperTriangular(sTu)) == "TUUF"
-    @test MKLSparse.matdescra(sA) == "GUUF"
+    @test MKLSparse.matdescra(sA) == "GFNF"
 end
 
 # evaluates ex and checks whether it has called any SparseBLAS MKL method


### PR DESCRIPTION
This is a subset of #30 excluding the `Matrix * SparseMatrix`:
* ~~adds support for MKL 2023.x~~
* simplifies the MKLSparse wrappers by introducing `mkl_call(funcname, T, args...)` generated function that automatically transforms templates like `mkl_Tcscmv` into appropriate MKLSparse function names for a specific input types (e.g. `mkl_dcscmv`).
* `@eval`-based generation of all possible wrapper method parameter combinations is replaced by a single method with a proper signature and the use of `mkl_call()` that automatically generates a proper method MKLSparse method name to call. That should make debugging and code coverage analysis easier.
* some unnecessary "type piracy" of `Base.*` was removed, I've also added comments explaining the motivation for specific LinearAlgrebra/Base (re)definitions
* **fixes 4-arg ldiv!()** from `ldiv!(a, A, B, C)` to `ldiv!(C, A, B, a)` to be compatible with 3-arg `ldiv!()` already in Base (AFAIK 4-arg is only defined in MKLSparse). This would break any packages/script that use *MKLSparse.jl* 4-arg `ldiv!()`, but this should be a rather exotic case.
* streamlines testing, so that all combination of sparse matrix value, index types, storage as well as triangular, symmetric, adjoint and transposed are covered
* `@test_blas` macro replaced by conventional `@test` macro in combination with `@blas` macro that allows more fine-grained checks of whether Sparse BLAS MKL methods are being called
* in tests `maximum(abs.(...)) <= eps` is replaced with `≈ atol=...`
* update CI.yml to use julia-actions
* enable code coverage

No new version of *MKLSparse.jl* was tagged after #31 got merged. It could be done before/after this PR.